### PR TITLE
[FIO toup] imx7ulp: fiohab: support tool to enable closing the device

### DIFF
--- a/arch/arm/mach-imx/Makefile
+++ b/arch/arm/mach-imx/Makefile
@@ -49,7 +49,7 @@ obj-$(CONFIG_SYSCOUNTER_TIMER) += syscounter.o
 endif
 ifeq ($(SOC),$(filter $(SOC),mx7ulp))
 obj-y  += cache.o
-obj-$(CONFIG_IMX_HAB) += hab.o
+obj-$(CONFIG_IMX_HAB) += hab.o fiohab.o
 endif
 ifeq ($(SOC),$(filter $(SOC),vf610))
 obj-y += ddrmc-vf610.o

--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2019 Foundries.IO
+ */
+
+#include <common.h>
+#include <config.h>
+#include <fuse.h>
+#include <mapmem.h>
+#include <image.h>
+#include <asm/io.h>
+#include <asm/system.h>
+#include <asm/arch/clock.h>
+#include <asm/arch/sys_proto.h>
+#include <asm/mach-imx/hab.h>
+
+#ifdef CONFIG_MX7ULP
+#define SRK_FUSE_BANK		(5)
+#define SRK_FIRST_FUSE		(0)
+#define SRK_NBR_FUSE		(8)
+#define SECURE_FUSE_BANK	(29)
+#define SECURE_FUSE_WORD	(6)
+#define SECURE_FUSE_VALUE	(0x80000000)
+#else
+#error "SoC not supported"
+#endif
+
+static hab_rvt_report_status_t *hab_check;
+
+static int hab_status(void)
+{
+	hab_check = (hab_rvt_report_status_t *) HAB_RVT_REPORT_STATUS;
+	enum hab_config config = 0;
+	enum hab_state state = 0;
+
+	if (hab_check(&config, &state) != HAB_SUCCESS) {
+		printf("HAB events active\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+static int do_fiohab_close(cmd_tbl_t *cmdtp, int flag, int argc,
+			   char *const argv[])
+{
+	char fuse_name[20] = { '\0' };
+	uint32_t fuse, fuse_env;
+	int i, j;
+	int ret;
+
+	if (argc != 1) {
+		cmd_usage(cmdtp);
+		return 1;
+	}
+
+	if (imx_hab_is_enabled()) {
+		printf("secure boot already enabled\n");
+		return 0;
+	}
+
+	if (hab_status())
+		return 1;
+
+	for (i = SRK_FIRST_FUSE, j = 0;
+	     i < SRK_FIRST_FUSE + SRK_NBR_FUSE; i++, j++) {
+		ret = fuse_read(SRK_FUSE_BANK, i, &fuse);
+		if (ret) {
+			printf("Secure boot fuse read error\n");
+			return 1;
+		}
+
+		sprintf(fuse_name, "srk_%d", i);
+		fuse_env = (uint32_t) env_get_hex(fuse_name, 0);
+		if (!fuse_env) {
+			printf("%s not in environment\n", fuse_name);
+			return 1;
+		}
+
+		if (fuse_env != fuse) {
+			printf("%s - programmed: 0x%x != expected: 0x%x \n",
+				fuse_name, fuse, fuse_env);
+			return 1;
+		}
+	}
+
+	ret = fuse_prog(SECURE_FUSE_BANK, SECURE_FUSE_WORD, SECURE_FUSE_VALUE);
+	if (ret) {
+		printf("Error writing the Secure Fuse\n");
+		return 1;
+	}
+
+	return 0;
+}
+
+U_BOOT_CMD(fiohab_close, CONFIG_SYS_MAXARGS, 1, do_fiohab_close,
+	   "Close the board for HAB","");
+


### PR DESCRIPTION
The UUU script should look as follows (ie, pass the SRK keys for the
platform)

   uuu_version 1.0.1
   SDP: boot -f SPL-aeler-imx7ulpea-ucom -dcdaddr 0x2f010000 -cleardcd
   SDPU: delay 1000
   SDPU: write -f u-boot-aeler-imx7ulpea-ucom.itb
   SDPU: jump

   FB: ucmd setenv srk_0 0xEA2F0B50
   FB: ucmd setenv srk_1 0x871167F7
   FB: ucmd setenv srk_2 0xF5CECF5D
   FB: ucmd setenv srk_3 0x364727C3
   FB: ucmd setenv srk_4 0x8DD52832
   FB: ucmd setenv srk_5 0xF158F65F
   FB: ucmd setenv srk_6 0xA71BBE78
   FB: ucmd setenv srk_7 0xA3AD024A
   FB: ucmd if fiohab_close; then echo Platform Secured; \
       else echo Can Not Secure the Platform; fi
   FBK: DONE

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
