### PR TITLE
[FIO toup] watchdog: fix imx7ulp init

### DIFF
--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -104,14 +104,29 @@ int board_postclk_init(void)
 
 static void disable_wdog(u32 wdog_base)
 {
-	writel(UNLOCK_WORD0, (wdog_base + 0x04));
-	writel(UNLOCK_WORD1, (wdog_base + 0x04));
+	u32 val_cs = readl(wdog_base + 0x00);
+
+	if (!(val_cs & 0x80))
+		return;
+
+	dmb();
+	__raw_writel(REFRESH_WORD0, (wdog_base + 0x04)); /* Refresh the CNT */
+	__raw_writel(REFRESH_WORD1, (wdog_base + 0x04));
+	dmb();
+
+	if (!(val_cs & 800)) {
+		dmb();
+		__raw_writel(UNLOCK_WORD0, (wdog_base + 0x04));
+		__raw_writel(UNLOCK_WORD1, (wdog_base + 0x04));
+		dmb();
+
+		while (!(readl(wdog_base + 0x00) & 0x800));
+	}
 	writel(0x0, (wdog_base + 0x0C)); /* Set WIN to 0 */
 	writel(0x400, (wdog_base + 0x08)); /* Set timeout to default 0x400 */
 	writel(0x120, (wdog_base + 0x00)); /* Disable it and set update */
 
-	writel(REFRESH_WORD0, (wdog_base + 0x04)); /* Refresh the CNT */
-	writel(REFRESH_WORD1, (wdog_base + 0x04));
+	while (!(readl(wdog_base + 0x00) & 0x400));
 }
 
 void init_wdog(void)

--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -122,9 +122,11 @@ static void disable_wdog(u32 wdog_base)
 
 		while (!(readl(wdog_base + 0x00) & 0x800));
 	}
-	writel(0x0, (wdog_base + 0x0C)); /* Set WIN to 0 */
-	writel(0x400, (wdog_base + 0x08)); /* Set timeout to default 0x400 */
-	writel(0x120, (wdog_base + 0x00)); /* Disable it and set update */
+	dmb();
+	__raw_writel(0x0, wdog_base + 0x0C); /* Set WIN to 0 */
+	__raw_writel(0x400, wdog_base + 0x08); /* Set timeout to default 0x400 */
+	__raw_writel(0x120, wdog_base + 0x00); /* Disable it and set update */
+	dmb();
 
 	while (!(readl(wdog_base + 0x00) & 0x400));
 }


### PR DESCRIPTION
These fixes came from Codeaurora - basically they enforce the
reconfiguration sequence timing requirements. We should have them
upstream (I need to find the original author to credit)

Signed-off-by: Jorge Ramirez <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
