### PR TITLE
[FIO internal] configs: mx7ulpea: disable FSL_QSPI_AHB

### DIFF
--- a/include/configs/mx7ulpea-ucom.h
+++ b/include/configs/mx7ulpea-ucom.h
@@ -145,7 +145,6 @@
 
 /* QSPI configs */
 #ifdef CONFIG_FSL_QSPI
-#define CONFIG_SYS_FSL_QSPI_AHB
 #define FSL_QSPI_FLASH_NUM              1
 #define FSL_QSPI_FLASH_SIZE             SZ_8M
 #define QSPI0_BASE_ADDR                 0x410A5000


### PR DESCRIPTION
With this configuration enabled, if the M4 requires access to QSPI it
needs to clear the Buffer Generic Configuration Register
(QSPI_BFGENCR).

As a precaution we will keep this option disabled - otherwise M4
upgrades that might not clear that register will be stuck while
booting.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
