### PR TITLE
[FIO extras] imx: imx7ulpea-ucom-kit_v2: add sys_reset config

### DIFF
--- a/arch/arm/dts/imx7ulpea-ucom-kit_v2.dts
+++ b/arch/arm/dts/imx7ulpea-ucom-kit_v2.dts
@@ -103,7 +103,7 @@
 
 &iomuxc1 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_hog_1>;
+	pinctrl-0 = <&pinctrl_hog_1 &pinctrl_sys_reset>;
 
 	imx7ulpea-ucom {
 		pinctrl_hog_1: hoggrp-1 {
@@ -199,6 +199,12 @@
 		pinctrl_usbotg1_id: otg1idgrp {
 			fsl,pins = <
 				IMX7ULP_PAD_PTC13__USB0_ID	0x10003
+			>;
+		};
+
+		pinctrl_sys_reset: sysrstgrp {
+			fsl,pins = <
+				IMX7ULP_PAD_PTC10__PTC10        0x20000 /* SYS_RESET */
 			>;
 		};
 	};


### PR DESCRIPTION
- Add PTC10 GPIO for use as a system reset line

NOTE: This only works for specific HW that has the line connected.

Signed-off-by: Michael Scott <mike@foundries.io>