### PR TITLE
mx7ulp: Only enable LDO if it is not already enabled

### DIFF
--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -150,10 +150,27 @@ void init_wdog(void)
 	disable_wdog(WDG2_RBASE);
 }
 
+#define PMC0_BASE_ADDR		0x410a1000
+#define PMC0_CTRL		0x28
+#define PMC0_CTRL_LDOEN		BIT(31)
+
+static bool ldo_mode_is_enabled(void)
+{
+	unsigned int reg;
+
+	reg = readl(PMC0_BASE_ADDR + PMC0_CTRL);
+	if (reg & PMC0_CTRL_LDOEN)
+		return true;
+	else
+		return false;
+}
 #if defined(CONFIG_LDO_ENABLED_MODE)
 static void init_ldo_mode(void)
 {
 	unsigned int reg;
+
+	if (ldo_mode_is_enabled())
+		return;
 
 	/* Set LDOOKDIS */
 	setbits_le32(PMC0_BASE_ADDR + PMC0_CTRL, PMC0_CTRL_LDOOKDIS);
@@ -221,21 +238,6 @@ void reset_cpu(ulong addr)
 const char *get_imx_type(u32 imxtype)
 {
 	return "7ULP";
-}
-
-#define PMC0_BASE_ADDR		0x410a1000
-#define PMC0_CTRL		0x28
-#define PMC0_CTRL_LDOEN		BIT(31)
-
-static bool ldo_mode_is_enabled(void)
-{
-	unsigned int reg;
-
-	reg = readl(PMC0_BASE_ADDR + PMC0_CTRL);
-	if (reg & PMC0_CTRL_LDOEN)
-		return true;
-	else
-		return false;
 }
 
 int print_cpuinfo(void)


### PR DESCRIPTION
LDO mode may be already enabled by the ROM and enabling it again
can cause U-Boot to hang.

Avoid this problem by only enabling LDO mode if it is initially disabled.

Reported-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
Signed-off-by: Fabio Estevam <festevam@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
