### PR TITLE
[FIO fromtree] mx7ulp: soc: s_init should only be executed once

### DIFF
--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -164,6 +164,8 @@ static bool ldo_mode_is_enabled(void)
 	else
 		return false;
 }
+
+#if !defined(CONFIG_SPL) || (defined(CONFIG_SPL) && defined(CONFIG_SPL_BUILD))
 #if defined(CONFIG_LDO_ENABLED_MODE)
 static void init_ldo_mode(void)
 {
@@ -224,6 +226,7 @@ void s_init(void)
 #endif
 	return;
 }
+#endif
 
 #if !defined(CONFIG_ULP_WATCHDOG) || defined(CONFIG_SPL_BUILD)
 void reset_cpu(ulong addr)


### PR DESCRIPTION
On SPL enabled systems, the current s_init code (wdog, clock and ldo
init) is executed twice (by SPL and u-boot). This is not necessary and
might lead to boot issues (ie, starting PMC1 when it is already
running).

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
