### PR TITLE
[FIO fromlist] mx6: peripheral clock from oscillator

### DIFF
--- a/arch/arm/mach-imx/mx6/soc.c
+++ b/arch/arm/mach-imx/mx6/soc.c
@@ -655,7 +655,7 @@ int arch_cpu_init(void)
 	}
 
 	/* Set perclk to source from OSC 24MHz */
-	if (is_mx6sl())
+	if (is_mx6sl() || is_mx6ull())
 		set_preclk_from_osc();
 
 	imx_wdog_disable_powerdown(); /* Disable PDE bit of WMCR register */


### PR DESCRIPTION
In order to be able to run the I2C bus at 400Khz, the chip errata[1]
recommends that the peripheral clock runs out of the 24MHz oscillator.

[1] Rev 2, 10/2019, ERR007805

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
