### PR TITLE
iMX8mm: support Foundries.io secure boot

### DIFF
--- a/arch/arm/mach-imx/imx8m/Kconfig
+++ b/arch/arm/mach-imx/imx8m/Kconfig
@@ -2,8 +2,10 @@ if ARCH_IMX8M
 
 config IMX8M
 	bool
-	select HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
+	help
+	  This architecture has CAAM but we have decided to unselect
+	  it so we can enable Foundries.io secure boot (spl + itb)
 
 config IMX8MQ
 	bool

--- a/cmd/bootm.c
+++ b/cmd/bootm.c
@@ -123,7 +123,7 @@ int do_bootm(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 			return do_bootm_subcommand(cmdtp, flag, argc, argv);
 	}
 
-#ifdef CONFIG_IMX_HAB
+#if defined(CONFIG_IMX_HAB) && !defined(CONFIG_IMX8M)
 	extern int authenticate_image(
 			uint32_t ddr_start, uint32_t raw_image_size);
 


### PR DESCRIPTION
This requires the following configuration files:

[uboot.config.txt](https://github.com/foundriesio/u-boot/files/5502247/uboot.config.txt)
[uboot.mfgtool.config.txt](https://github.com/foundriesio/u-boot/files/5502249/uboot.mfgtool.config.txt)
