### PR TITLE
[FIO toup] imx6: fiohab: add handling for imx6

### DIFF
--- a/arch/arm/mach-imx/Makefile
+++ b/arch/arm/mach-imx/Makefile
@@ -61,7 +61,10 @@ obj-$(CONFIG_IMX_TRUSTY_OS) += trusty.o
 endif
 ifeq ($(SOC),$(filter $(SOC),mx7ulp))
 obj-y  += cache.o mmdc_size.o
-obj-$(CONFIG_IMX_HAB) += hab.o fiohab.o
+obj-$(CONFIG_IMX_HAB) += hab.o
+endif
+ifeq ($(SOC),$(filter $(SOC),mx6 mx7ulp))
+obj-$(CONFIG_IMX_HAB) += fiohab.o
 endif
 ifeq ($(SOC),$(filter $(SOC),vf610))
 obj-y += ddrmc-vf610.o

--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -81,6 +81,12 @@ static int fiovb_provisioned(void)
 #define SECURE_FUSE_BANK	(29)
 #define SECURE_FUSE_WORD	(6)
 #define SECURE_FUSE_VALUE	(0x80000000)
+#elif CONFIG_ARCH_MX6
+#define SRK_FUSE_LIST								\
+{ 3, 0 }, { 3, 1 }, { 3, 2}, { 3, 3 }, { 3, 4 }, { 3, 5}, { 3, 6 }, { 3 ,7 },
+#define SECURE_FUSE_BANK	(0)
+#define SECURE_FUSE_WORD	(6)
+#define SECURE_FUSE_VALUE	(0x00000002)
 #else
 #error "SoC not supported"
 #endif


### PR DESCRIPTION
All of the i.MX6 processors use the same SRK_HASH and
SEC_CONFIG[1] fuses to support secure boot.

Signed-off-by: Michael Scott <mike@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
