### PR TITLE
[FIO toup] arch: mach-imx: hab: add SPL_IMX_HAB config

### DIFF
--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -79,6 +79,14 @@ config IMX_HAB
 	  This option enables the support for secure boot (HAB).
 	  See doc/README.mxc_hab for more details.
 
+config SPL_IMX_HAB
+	bool "Support i.MX HAB features in SPL"
+	default y if IMX_HAB
+	depends on ARCH_MX7 || ARCH_MX6 || ARCH_MX5 || ARCH_MX7ULP || ARCH_IMX8M
+	help
+	  This option enables the support for secure boot (HAB) in SPL.
+	  See doc/README.mxc_hab for more details.
+
 config CSF_SIZE
 	hex "Maximum size for Command Sequence File (CSF) binary"
 	default 0x2060

--- a/arch/arm/mach-imx/Makefile
+++ b/arch/arm/mach-imx/Makefile
@@ -16,7 +16,7 @@ endif
 obj-y += mmc_env.o
 obj-$(CONFIG_FEC_MXC) += mac.o
 obj-$(CONFIG_SYS_I2C_MXC) += i2c-mxv7.o
-obj-$(CONFIG_IMX_HAB) += hab.o
+obj-$(CONFIG_$(SPL_)IMX_HAB) += hab.o
 obj-y += cpu.o
 endif
 
@@ -55,16 +55,16 @@ ifneq ($(CONFIG_SPL_BUILD),y)
 obj-$(CONFIG_IMX_BOOTAUX) += imx_bootaux.o
 endif
 obj-$(CONFIG_SATA) += sata.o
-obj-$(CONFIG_IMX_HAB)    += hab.o
+obj-$(CONFIG_$(SPL_)IMX_HAB)    += hab.o
 obj-$(CONFIG_SYSCOUNTER_TIMER) += syscounter.o
 obj-$(CONFIG_IMX_TRUSTY_OS) += trusty.o
 endif
 ifeq ($(SOC),$(filter $(SOC),mx7ulp))
 obj-y  += cache.o mmdc_size.o
-obj-$(CONFIG_IMX_HAB) += hab.o
+obj-$(CONFIG_$(SPL_)IMX_HAB) += hab.o
 endif
 ifeq ($(SOC),$(filter $(SOC),mx6 mx7ulp))
-obj-$(CONFIG_IMX_HAB) += fiohab.o
+obj-$(CONFIG_$(SPL_)IMX_HAB) += fiohab.o
 endif
 ifeq ($(SOC),$(filter $(SOC),vf610))
 obj-y += ddrmc-vf610.o

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -274,7 +274,7 @@ u32 spl_boot_mode(const u32 boot_device)
 }
 #endif
 
-#if defined(CONFIG_IMX_HAB)
+#if defined(CONFIG_SPL_IMX_HAB)
 
 /*
  * +------------+  0x0 (DDR_UIMAGE_START) -


### PR DESCRIPTION
This allows granularity of turning off HAB features for SPL
which might not need them.

Signed-off-by: Michael Scott <mike@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
