### PR TITLE
[FIO internal] fiohab: remove safeguard for incorrect rpmb key

### DIFF
--- a/arch/arm/dts/imx6ull-14x14-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx6ull-14x14-evk-u-boot.dtsi
@@ -23,6 +23,11 @@
 	u-boot,dm-spl;
 };
 
+&aips3 {
+	u-boot,dm-pre-reloc;
+	u-boot,dm-spl;
+};
+
 &uart1 {
 	u-boot,dm-pre-reloc;
 	u-boot,dm-spl;
@@ -50,6 +55,11 @@
 };
 
 &reg_sd1_vmmc {
+        u-boot,dm-pre-reloc;
+        u-boot,dm-spl;
+};
+
+&rngb {
         u-boot,dm-pre-reloc;
         u-boot,dm-spl;
 };

--- a/arch/arm/dts/imx6ull.dtsi
+++ b/arch/arm/dts/imx6ull.dtsi
@@ -67,6 +67,13 @@
 				clock-names = "dcp";
 			};
 
+			rngb: rng@2284000 {
+				compatible = "fsl,imx6ull-rngb", "fsl,imx25-rngb";
+				reg = <0x02284000 0x4000>;
+				interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
+				clocks = <&clks IMX6UL_CLK_DUMMY>;
+			};
+
 			iomuxc_snvs: iomuxc-snvs@2290000 {
 				compatible = "fsl,imx6ull-iomuxc-snvs";
 				reg = <0x02290000 0x4000>;


### PR DESCRIPTION
The initial check was done to cover cases in which the RPMB key is
already burned (e.g. test keys), to block the close process as that
would result in OP-TEE using the HUK-derived RPMB key instead.

This causes a few problems:
- Will not work on devices without eMMC/RPMB
- Can end up burning the wrong RPMB key (bugs in OP-TEE)
- Always cause a panic during the closing process

Remove as fusing shouldn't be blocked by the RPMB state.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>