### PR TITLE
mx7ulp fixes

### DIFF
--- a/arch/arm/mach-imx/mx7ulp/Kconfig
+++ b/arch/arm/mach-imx/mx7ulp/Kconfig
@@ -9,7 +9,7 @@ config LDO_ENABLED_MODE
 	  Select this option to enable the PMC1 LDO.
 
 config MX7ULP
-	select HAS_CAAM
+	select HAS_CAAM if !OPTEE
 	bool
 
 config IMX_M4_BIND

--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -425,7 +425,6 @@ void arch_preboot_os(void)
 	scg_disable_pll_pfd(SCG_APLL_PFD3_CLK);
 }
 
-#ifdef CONFIG_ENV_IS_IN_MMC
 __weak int board_mmc_get_env_dev(int devno)
 {
 	return devno;
@@ -445,7 +444,6 @@ int mmc_get_env_dev(void)
 
 	return board_mmc_get_env_dev(devno);
 }
-#endif
 
 enum boot_device get_boot_device(void)
 {

--- a/drivers/fpga/Kconfig
+++ b/drivers/fpga/Kconfig
@@ -87,6 +87,7 @@ config FPGA_ZYNQPL
 
 config FPGA_IMX_M4
 	bool "Enable FPGA IMX M4 - boot/upgrade"
+	select FPGA
 	help
 	  Enable FPGA driver for loading a bitstream to an IMX M4 coprocessor.
 	  This allows the firmware to either be boot or upgraded and boot.


### PR DESCRIPTION
- mx7ulp: Decouple mmc_get_env_dev with CONFIG_ENV_IS_IN_MMC
- mx7ulp: dont select HAS_CAAM if OPTEE is selected
- fpga: imx_m4: select FPGA when FPGA_IMX_M4 is selected