### PR TITLE
ARM: imx8mq: add define for SRC_GPR10_PERSIST_SECONDARY_BOOT bit

### DIFF
--- a/arch/arm/include/asm/arch-imx8m/imx-regs-imx8mq.h
+++ b/arch/arm/include/asm/arch-imx8m/imx-regs-imx8mq.h
@@ -162,6 +162,8 @@
 
 #define SNVS_HPSR              (SNVS_HP_BASE_ADDR + 0x14)
 
+#define SRC_GPR10_PERSIST_SECONDARY_BOOT	BIT(30)
+
 struct iomuxc_gpr_base_regs {
 	u32 gpr[48];
 };


### PR DESCRIPTION
Add define for SRC_GPR10_PERSIST_SECONDARY_BOOT bit for iMX8MQ SoC.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

