### PR TITLE
[FIO internal] rsa: force mod exp sw implementation for non-dm case

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -366,7 +366,6 @@ config FIT_ENABLE_SHA256_SUPPORT
 
 config FIT_SIGNATURE
 	bool "Enable signature verification of FIT uImages"
-	depends on DM
 	select HASH
 	select RSA
 	help
@@ -458,7 +457,6 @@ config SPL_FIT_PRINT
 
 config SPL_FIT_SIGNATURE
 	bool "Enable signature verification of FIT firmware within SPL"
-	depends on SPL_DM
 	select SPL_FIT
 	select SPL_RSA
 

--- a/lib/rsa/rsa-verify.c
+++ b/lib/rsa/rsa-verify.c
@@ -292,7 +292,9 @@ static int rsa_verify_key(struct image_sign_info *info,
 {
 	int ret;
 #if !defined(USE_HOSTCC)
+#if CONFIG_IS_ENABLED(DM)
 	struct udevice *mod_exp_dev;
+#endif
 #endif
 	struct checksum_algo *checksum = info->checksum;
 	struct padding_algo *padding = info->padding;
@@ -319,6 +321,7 @@ static int rsa_verify_key(struct image_sign_info *info,
 	hash_len = checksum->checksum_len;
 
 #if !defined(USE_HOSTCC)
+#if CONFIG_IS_ENABLED(DM)
 	ret = uclass_get_device(UCLASS_MOD_EXP, 0, &mod_exp_dev);
 	if (ret) {
 		printf("RSA: Can't find Modular Exp implementation\n");
@@ -326,6 +329,9 @@ static int rsa_verify_key(struct image_sign_info *info,
 	}
 
 	ret = rsa_mod_exp(mod_exp_dev, sig, sig_len, prop, buf);
+#else
+	ret = rsa_mod_exp_sw(sig, sig_len, prop, buf);
+#endif
 #else
 	ret = rsa_mod_exp_sw(sig, sig_len, prop, buf);
 #endif


### PR DESCRIPTION
Force to use SW implementation of EXP MOD if Driver Model is disabled.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
