### PR TITLE
SPL size shrink patches

### DIFF
--- a/arch/arm/dts/imx6ull-14x14-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx6ull-14x14-evk-u-boot.dtsi
@@ -8,55 +8,9 @@
 	u-boot,dm-spl;
 };
 
-&aips1 {
-	u-boot,dm-pre-reloc;
-	u-boot,dm-spl;
-
-	spba-bus@2000000 {
-		u-boot,dm-pre-reloc;
-		u-boot,dm-spl;
-	};
-};
-
-&aips2 {
-	u-boot,dm-pre-reloc;
-	u-boot,dm-spl;
-};
-
 &aips3 {
 	u-boot,dm-pre-reloc;
 	u-boot,dm-spl;
-};
-
-&uart1 {
-	u-boot,dm-pre-reloc;
-	u-boot,dm-spl;
-};
-
-&iomuxc {
-	u-boot,dm-pre-reloc;
-	u-boot,dm-spl;
-};
-
-/* only enable the active boot device */
-&usdhc2 {
-        u-boot,dm-pre-reloc;
-        u-boot,dm-spl;
-};
-
-&gpio1 {
-        u-boot,dm-pre-reloc;
-        u-boot,dm-spl;
-};
-
-&gpio2 {
-        u-boot,dm-pre-reloc;
-        u-boot,dm-spl;
-};
-
-&reg_sd1_vmmc {
-        u-boot,dm-pre-reloc;
-        u-boot,dm-spl;
 };
 
 &rngb {

--- a/common/hash.c
+++ b/common/hash.c
@@ -93,6 +93,8 @@ static int hash_finish_sha256(struct hash_algo *algo, void *ctx, void
 }
 #endif
 
+#if (defined(CONFIG_SPL_BUILD) && !defined(CONFIG_SPL_FIT_SIGNATURE_STRICT)) || \
+    (!defined(CONFIG_SPL_BUILD) && !defined(CONFIG_FIT_SIGNATURE_STRICT))
 static int hash_init_crc16_ccitt(struct hash_algo *algo, void **ctxp)
 {
 	uint16_t *ctx = malloc(sizeof(uint16_t));
@@ -119,6 +121,7 @@ static int hash_finish_crc16_ccitt(struct hash_algo *algo, void *ctx,
 	free(ctx);
 	return 0;
 }
+#endif
 
 static int hash_init_crc32(struct hash_algo *algo, void **ctxp)
 {
@@ -194,6 +197,8 @@ static struct hash_algo hash_algo[] = {
 #endif
 	},
 #endif
+#if (defined(CONFIG_SPL_BUILD) && !defined(CONFIG_SPL_FIT_SIGNATURE_STRICT)) || \
+    (!defined(CONFIG_SPL_BUILD) && !defined(CONFIG_FIT_SIGNATURE_STRICT))
 	{
 		.name		= "crc16-ccitt",
 		.digest_size	= 2,
@@ -203,6 +208,7 @@ static struct hash_algo hash_algo[] = {
 		.hash_update	= hash_update_crc16_ccitt,
 		.hash_finish	= hash_finish_crc16_ccitt,
 	},
+#endif
 	{
 		.name		= "crc32",
 		.digest_size	= 4,

--- a/common/hash.c
+++ b/common/hash.c
@@ -123,6 +123,7 @@ static int hash_finish_crc16_ccitt(struct hash_algo *algo, void *ctx,
 }
 #endif
 
+#if !defined(CONFIG_SPL_BUILD) || defined(CONFIG_SPL_CRC32_SUPPORT)
 static int hash_init_crc32(struct hash_algo *algo, void **ctxp)
 {
 	uint32_t *ctx = malloc(sizeof(uint32_t));
@@ -148,6 +149,7 @@ static int hash_finish_crc32(struct hash_algo *algo, void *ctx, void *dest_buf,
 	free(ctx);
 	return 0;
 }
+#endif
 
 /*
  * These are the hash algorithms we support.  If we have hardware acceleration
@@ -209,6 +211,7 @@ static struct hash_algo hash_algo[] = {
 		.hash_finish	= hash_finish_crc16_ccitt,
 	},
 #endif
+#if !defined(CONFIG_SPL_BUILD) || defined(CONFIG_SPL_CRC32_SUPPORT)
 	{
 		.name		= "crc32",
 		.digest_size	= 4,
@@ -218,6 +221,7 @@ static struct hash_algo hash_algo[] = {
 		.hash_update	= hash_update_crc32,
 		.hash_finish	= hash_finish_crc32,
 	},
+#endif
 };
 
 /* Try to minimize code size for boards that don't want much hashing */


### PR DESCRIPTION
These 3 patches attempt to shrink the size of SPL so that we can use mfgtools on imx6ullevk just like any other board.

- Reduce the SPL DTS to OP-TEE only required nodes (none needed due to SPL_DM disable)
- hash: Drop any CRC32 code if SPL_CRC32_SUPPORT is not enabled
- hash: Drop CRC16 code if FIT_SIGNATURE_STRICT enabled