### PR TITLE
imx8mq: add definition for SRC_SBMR2_SEC_CONFIG

### DIFF
--- a/arch/arm/include/asm/arch-imx8m/imx-regs-imx8mq.h
+++ b/arch/arm/include/asm/arch-imx8m/imx-regs-imx8mq.h
@@ -163,6 +163,7 @@
 #define SNVS_HPSR              (SNVS_HP_BASE_ADDR + 0x14)
 
 #define SRC_GPR10_PERSIST_SECONDARY_BOOT	BIT(30)
+#define SRC_SBMR2_SEC_CONFIG			BIT(1)
 
 struct iomuxc_gpr_base_regs {
 	u32 gpr[48];


### PR DESCRIPTION
```
Add definition for SRC_SBMR2_SEC_CONFIG bit.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```
Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
