### PR TITLE
[FIO internal] mx6ullevk: spl select proper reset_cpu

### DIFF
--- a/board/freescale/mx6ullevk/spl.c
+++ b/board/freescale/mx6ullevk/spl.c
@@ -93,6 +93,8 @@ void board_init_f(ulong dummy)
 	board_init_r(NULL, 0);
 }
 
+#ifndef CONFIG_SPL_SYSRESET
 void reset_cpu(ulong addr)
 {
 }
+#endif


### PR DESCRIPTION
If the CONFIG_SPL_SYSRESET is defined there is multiple definitions
of the reset_cpu() function. This turns off the one in SPL in that
case.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
