### PR TITLE
[FIO internal] arm: use default implementation of do_reset for SPL

### DIFF
--- a/arch/arm/lib/Makefile
+++ b/arch/arm/lib/Makefile
@@ -57,8 +57,15 @@ obj-y	+= interrupts_64.o
 else
 obj-y	+= interrupts.o
 endif
+
+ifndef CONFIG_SPL_BUILD
 ifndef CONFIG_SYSRESET
 obj-y	+= reset.o
+endif
+else
+ifndef CONFIG_SPL_SYSRESET
+obj-y	+= reset.o
+endif
 endif
 
 obj-y	+= cache.o


### PR DESCRIPTION
Use default implementation of do_reset() for SPL build if SPL_SYSRESET
is not set.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
