### PR TITLE
[FIO internal] ARM: dts: imx6-apalis: fix memory node

### DIFF
--- a/arch/arm/dts/imx6-apalis.dts
+++ b/arch/arm/dts/imx6-apalis.dts
@@ -14,7 +14,7 @@
 	/* Will be filled by the bootloader */
 	memory@10000000 {
 		device_type = "memory";
-		reg = <0x10000000 0>;
+		reg = <0x10000000 0x40000000>;
 	};
 
 	aliases {


### PR DESCRIPTION
Provide proper size of RAM in memory node.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
