### PR TITLE
imx: drop imx_warm_reset workaround

### DIFF
--- a/arch/arm/mach-imx/imx_secondary_boot.c
+++ b/arch/arm/mach-imx/imx_secondary_boot.c
@@ -93,20 +93,3 @@ U_BOOT_CMD(
 	imx_is_closed, CONFIG_SYS_MAXARGS, 1, do_imx_is_closed,
 	"Check if the board is closed", ""
 );
-
-
-#if CONFIG_IS_ENABLED(ARCH_IMX8M)
-static int do_warm_reset(cmd_tbl_t *cmdtp, int flag,
-			 int argc, char * const argv[])
-{
-	arm_smccc_smc(IMX_SIP_WARM_RESET, 0, 0, 0, 0, 0, 0, 0, NULL);
-
-	return CMD_RET_SUCCESS;
-}
-
-U_BOOT_CMD(
-	imx_warm_reset, CONFIG_SYS_MAXARGS, 1, do_warm_reset,
-	"Assert WDOG Software Reset Signal (internal reset) via TF-A",
-	"\n"
-);
-#endif /* CONFIG_IS_ENABLED(ARCH_IMX8M) */


### PR DESCRIPTION
Drop imx_warm_reset command in favor of "reset -w", which
also triggers warm reset.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
