### PR TITLE
[FIO internal] spl: enable hw_watchdog for non-dm case

### DIFF
--- a/common/spl/spl.c
+++ b/common/spl/spl.c
@@ -669,8 +669,12 @@ void board_init_r(gd_t *dummy1, ulong dummy2)
 	spl_board_init();
 #endif
 
-#if defined(CONFIG_SPL_WATCHDOG_SUPPORT) && CONFIG_IS_ENABLED(WDT)
+#if defined(CONFIG_SPL_WATCHDOG_SUPPORT)
+#if CONFIG_IS_ENABLED(WDT)
 	initr_watchdog();
+#else /* SPL_HW_WATCHDOG */
+	hw_watchdog_init();
+#endif
 #endif
 
 	if (IS_ENABLED(CONFIG_SPL_OS_BOOT) || CONFIG_IS_ENABLED(HANDOFF) ||


### PR DESCRIPTION
Call hw_watchdog_init() for the case when SPL watchdog support is
enabled, however without DM support (CONFIG_WDT).

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
