### PR TITLE
[FIO extras] imx: fiohab: add support for IMX8MM

### DIFF
--- a/arch/arm/mach-imx/Makefile
+++ b/arch/arm/mach-imx/Makefile
@@ -63,7 +63,7 @@ ifeq ($(SOC),$(filter $(SOC),mx7ulp))
 obj-y  += cache.o mmdc_size.o
 obj-$(CONFIG_$(SPL_)IMX_HAB) += hab.o
 endif
-ifeq ($(SOC),$(filter $(SOC),mx6 mx7ulp))
+ifeq ($(SOC),$(filter $(SOC),mx6 mx7ulp imx8m))
 obj-$(CONFIG_$(SPL_)IMX_HAB) += fiohab.o
 endif
 ifeq ($(SOC),$(filter $(SOC),vf610))

--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -97,6 +97,12 @@ static int fiovb_provisioned(void)
 #define SECURE_FUSE_BANK	(0)
 #define SECURE_FUSE_WORD	(6)
 #define SECURE_FUSE_VALUE	(0x00000002)
+#elif CONFIG_IMX8MM
+#define SRK_FUSE_LIST								\
+{ 6, 0 }, { 6, 1 }, { 6, 2 }, { 6, 3 }, { 7, 0 }, { 7, 1 }, { 7, 2 }, { 7 , 3 },
+#define SECURE_FUSE_BANK	(1)
+#define SECURE_FUSE_WORD	(3)
+#define SECURE_FUSE_VALUE	(0x2000000)
 #else
 #error "SoC not supported"
 #endif


### PR DESCRIPTION
Add fuse list and banks used by IMX8MM.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>