### PR TITLE
drivers: fastboot: increase command buffer

### DIFF
--- a/drivers/fastboot/fb_fsl/fb_fsl_command.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_command.c
@@ -959,7 +959,7 @@ static void run_ucmd(char *cmd_parameter, char *response)
 	}
 }
 
-static char g_a_cmd_buff[64];
+static char g_a_cmd_buff[128];
 
 void fastboot_acmd_complete(void)
 {


### PR DESCRIPTION
Increase command buffer to 128 to avoid the "too long command"
error with the mfgtool scripts.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
