### PR TITLE
arch: arm: dts: imx8mm-evk-u-boot: add RPMB dev ID

### DIFF
--- a/arch/arm/dts/imx8mm-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx8mm-evk-u-boot.dtsi
@@ -8,6 +8,7 @@
 	aliases {
 		usbgadget0 = &usbg1;
 		usbgadget1 = &usbg2;
+		mmc2 = &usdhc3;
 	};
 
 	usbg1: usbg1 {
@@ -28,6 +29,7 @@
 		optee {
 			compatible = "linaro,optee-tz";
 			method = "smc";
+			rpmb-dev = <&usdhc3>;
 		};
 	};
 };


### PR DESCRIPTION
Set the RPMB dev ID node for imx8mm-evk-u-boot.dtsi as usdhc3. (eMMC
device).

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
