### PR TITLE
Revert "[FIO toup] mmc: fix uclass_get_device_by_seq check in mmc_ini…

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -3052,13 +3052,11 @@ int mmc_init_device(int num)
 	struct mmc *m;
 	int ret;
 
-	ret = uclass_get_device_by_seq(UCLASS_MMC, num, &dev);
-	if (ret)
-		return ret;
-
-	ret = uclass_get_device(UCLASS_MMC, num, &dev);
-	if (ret)
-		return ret;
+	if (uclass_get_device_by_seq(UCLASS_MMC, num, &dev)) {
+		ret = uclass_get_device(UCLASS_MMC, num, &dev);
+		if (ret)
+			return ret;
+	}
 
 	m = mmc_get_mmc_dev(dev);
 	if (!m)


### PR DESCRIPTION
…t_device"

This reverts commit 215950cb2452ecbab2cb769e5ef2fc831a4a9347.

Calling uclass_get_device() is a fallback after failed call of
uclass_get_device_by_seq(). The original code in 2153a08a24e is
correct and doesn't need to be fixed.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
