### PR TITLE
[FIO toup-squash] mmc: fsl_esdhc_imx: remove useless flags from 7ulp

### DIFF
--- a/drivers/mmc/fsl_esdhc_imx.c
+++ b/drivers/mmc/fsl_esdhc_imx.c
@@ -1672,8 +1672,8 @@ static struct esdhc_soc_data usdhc_imx8qm_data = {
 		ESDHC_FLAG_HS400 | ESDHC_FLAG_HS400_ES,
 };
 
-#define ESDHC_FLAG_STATE_LOST_IN_LPMODE BIT(10)
 #define ESDHC_FLAG_PMQOS		BIT(13)
+#define ESDHC_FLAG_STATE_LOST_IN_LPMODE BIT(14)
 
 static struct esdhc_soc_data usdhc_imx7ulp_data = {
 	.flags = ESDHC_FLAG_USDHC | ESDHC_FLAG_STD_TUNING


### PR DESCRIPTION
In U-Boot LP-related usdhc flags are useles. Remove them.

Fixes: e92f55f271 ("[FIO toup] mmc: fsl_esdhc_imx: initialize data for imx7ulp")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
