### PR TITLE
[FIO toup-squash] spl: imx: re-add missing imx7ulp boot devices

### DIFF
--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -31,6 +31,10 @@ __weak int spl_board_boot_device(enum boot_device boot_dev_spl)
 	case SD3_BOOT:
 	case MMC3_BOOT:
 		return BOOT_DEVICE_MMC1;
+#elif defined(CONFIG_MX7ULP)
+        case SD1_BOOT:
+        case MMC1_BOOT:
+                return BOOT_DEVICE_MMC1;
 #elif defined(CONFIG_IMX8)
 	case MMC1_BOOT:
 		return BOOT_DEVICE_MMC1;


### PR DESCRIPTION
These were lost during the rebase to imx_5.4.70_2.3.0

Next rebase, squash with commit: e6fc06b156a9c44c946298cf63a7c13189c7eb16

Signed-off-by: Michael Scott <mike@foundries.io>