### PR TITLE
[FIO extras] imx: fiohab: convert to cmd_tbl

### DIFF
--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -127,7 +127,7 @@ static int hab_status(void)
  * if RPMB keys have been provisioned as it would render it unavailable
  * afterwards
  */
-static int do_fiohab_close(cmd_tbl_t *cmdtp, int flag, int argc,
+static int do_fiohab_close(struct cmd_tbl *cmdtp, int flag, int argc,
 			   char *const argv[])
 {
 	struct srk_fuse {


### PR DESCRIPTION
Commit 091401131085 removed the cmd_tbl_t typedef, so update
the fiohab close command to use struct cmd_tbl instead.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>