### PR TITLE
[FIO internal-squash] watchdog: fix recursive dependency

### DIFF
--- a/common/spl/Kconfig
+++ b/common/spl/Kconfig
@@ -1262,7 +1262,6 @@ endif
 
 config SPL_WATCHDOG_SUPPORT
 	bool "Support watchdog drivers"
-	imply SPL_WDT if !SPL_HW_WATCHDOG
 	help
 	  Enable support for watchdog drivers in SPL. A watchdog is
 	  typically a hardware peripheral which can reset the system when it


### PR DESCRIPTION
Fix the recursive dependency [1] in Kconfig.

[1]
drivers/watchdog/Kconfig:24:error: recursive dependency detected!
drivers/watchdog/Kconfig:24:	symbol SPL_HW_WATCHDOG is selected by SPL_WDT
drivers/watchdog/Kconfig:253:	symbol SPL_WDT depends on SPL_HW_WATCHDOG

Fixes: f36bface6c ("[FIO internal] watchdog: introduce SPL_HW_WATCHDOG")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
