### PR TITLE
2021.04+imx fixes for apalis-imx6, apalis-imx8, and imx6ull-evk

### DIFF
--- a/arch/arm/cpu/armv8/fsl-layerscape/spl.c
+++ b/arch/arm/cpu/armv8/fsl-layerscape/spl.c
@@ -39,9 +39,6 @@ u32 spl_boot_device(void)
 
 #ifdef CONFIG_SPL_BUILD
 
-/* Define board data structure */
-static struct bd_info bdata __attribute__ ((section(".data")));
-
 void spl_board_init(void)
 {
 #if defined(CONFIG_NXP_ESBC) && defined(CONFIG_FSL_LSCH2)
@@ -78,7 +75,7 @@ void board_init_f(ulong dummy)
 	get_clocks();
 
 	preloader_console_init();
-	gd->bd = &bdata;
+	spl_set_bd();
 
 #ifdef CONFIG_SYS_I2C
 #ifdef CONFIG_SPL_I2C_SUPPORT

--- a/arch/arm/include/asm/arch-imx8/sys_proto.h
+++ b/arch/arm/include/asm/arch-imx8/sys_proto.h
@@ -21,9 +21,18 @@ struct pass_over_info_t {
 	u32 g_ap_mu;
 };
 
+#if defined(CONFIG_IMX8QM)
+#define FUSE_IMG_SET_OFF_WORD 464
+#elif defined(CONFIG_IMX8QXP) || defined (CONFIG_IMX8DXL)
+#define FUSE_IMG_SET_OFF_WORD 720
+#endif
+
 extern unsigned long rom_pointer[];
 void build_info(void);
 enum boot_device get_boot_device(void);
+int boot_mode_getprisec(void);
+int boot_mode_is_closed(void);
+void boot_mode_enable_secondary(bool enable);
 int print_bootinfo(void);
 int sc_pm_setup_uart(sc_rsrc_t uart_rsrc, sc_pm_clock_rate_t clk_rate);
 int imx8_power_domain_lookup_name(const char *name,

--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -24,7 +24,7 @@ config FSL_CAAM_KB
 config SECONDARY_BOOT_RUNTIME_DETECTION
 	bool "SD/MMC sector offset runtime detection"
 	default n
-	depends on (IMX8MQ || IMX8MM || IMX8MP || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP) && SPL_MMC_SUPPORT
+	depends on (IMX8MQ || IMX8MM || IMX8MP || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP) && SPL_MMC_SUPPORT
 	help
 	  Detect correct sector offset in SPL for the next boot image
 	  in runtime.
@@ -32,7 +32,7 @@ config SECONDARY_BOOT_RUNTIME_DETECTION
 config SECONDARY_BOOT_SECTOR_OFFSET
 	hex "SD/MMC sector offset used for ROM secondary boot"
 	default 0x0
-	depends on IMX8MQ || IMX8MM || IMX8MP || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP
+	depends on IMX8MQ || IMX8MM || IMX8MP || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP
 	help
 	  Set the sector offset to non-zero value in SPL used for
 	  secondary boot image. This value should be same as the

--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -55,7 +55,8 @@ config IMX_BOOTAUX
 config CMD_SECONDARY_BOOT
 	bool "Use SiP service exposed by trusted firmware for redundant boot control"
 	default n
-	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP
+	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_IMX8
+	select AHAB_BOOT if ARCH_IMX8
 	help
 	  Command for triggering SiP service provided by TF-A for setting/clearing
 	  SRC GPR10 PERSIST_SECONDARY_BOOT bit, that identifies which image will be

--- a/arch/arm/mach-imx/imx8/ahab.c
+++ b/arch/arm/mach-imx/imx8/ahab.c
@@ -285,6 +285,23 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc,
 	return 0;
 }
 
+#define AHAB_LIFECYCLE_OEM_CLOSED 0x80
+int boot_mode_is_closed(void)
+{
+	int err;
+	u16 lc;
+	err = sc_seco_chip_info(-1, &lc, NULL, NULL, NULL);
+	if (err != SC_ERR_NONE) {
+		printf("Error getting board AHAB lifecycle\n");
+		return -EIO;
+	}
+
+	if (lc == AHAB_LIFECYCLE_OEM_CLOSED)
+		return 1;
+
+	return 0;
+}
+
 static int confirm_close(void)
 {
 	puts("Warning: Please ensure your sample is in NXP closed state, "

--- a/arch/arm/mach-imx/imx8/image.c
+++ b/arch/arm/mach-imx/imx8/image.c
@@ -31,13 +31,6 @@
 #define SND_IMG_NUM_TO_OFF(num) \
         ((1UL << ((0 == (num)) ? 2 : (2 == (num)) ? 0 : (num))) * SND_IMG_OFF_UNIT)
 
-
-#if defined(CONFIG_IMX8QM)
-#define FUSE_IMG_SET_OFF_WORD 464
-#elif defined(CONFIG_IMX8QXP) || defined (CONFIG_IMX8DXL)
-#define FUSE_IMG_SET_OFF_WORD 720
-#endif
-
 static int __get_container_size(ulong addr, u16 *header_length)
 {
 	struct container_hdr *phdr;

--- a/arch/arm/mach-imx/imx8/misc.c
+++ b/arch/arm/mach-imx/imx8/misc.c
@@ -2,6 +2,7 @@
 #include <common.h>
 #include <log.h>
 #include <asm/arch/sci/sci.h>
+#include <asm/arch/sys_proto.h>
 #include <asm/mach-imx/sys_proto.h>
 #include <asm/global_data.h>
 #include <imx_sip.h>
@@ -136,6 +137,32 @@ void build_info(void)
 			V2X_PROD_VER(v2x_build), V2X_MAJOR_VER(v2x_build), V2X_MINOR_VER(v2x_build));
 	}
 	printf("\n");
+}
+
+int boot_mode_getprisec(void)
+{
+	int ret;
+	u8 set_id = 1;
+	u32 fuse_val = 0;
+	sc_ipc_t ipc_handle = -1;
+
+	if (!(is_imx8qxp() && is_soc_rev(CHIP_REV_B))) {
+		ret = sc_misc_get_boot_container(ipc_handle, &set_id);
+		/* Secondary boot */
+		if (!ret && set_id == 2) {
+			ret = sc_misc_otp_fuse_read(ipc_handle, FUSE_IMG_SET_OFF_WORD, &fuse_val);
+			if (!ret) {
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void boot_mode_enable_secondary(bool enable)
+{
+	printf("This functionality isn't supported on iMX8 SoC");
 }
 
 #if !defined(CONFIG_SPL_BUILD) && defined(CONFIG_PSCI_BOARD_REBOOT)

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -393,7 +393,8 @@ int mmc_image_load_late(struct mmc *mmc)
 #endif
 
 #if defined(CONFIG_SECONDARY_BOOT_RUNTIME_DETECTION) && \
-    defined(CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR)
+    defined(CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_SECTOR) && \
+    !defined(CONFIG_SPL_LOAD_IMX_CONTAINER)
 unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 					   unsigned long raw_sect)
 {
@@ -411,4 +412,11 @@ unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 
 	return offset;
 }
+
+#if defined(CONFIG_IMX8QM) || defined(CONFIG_IMX8QXP)
+int spl_mmc_emmc_boot_partition(struct mmc *mmc)
+{
+	return boot_mode_getprisec() ? 2 : 1;
+}
+#endif
 #endif

--- a/board/freescale/mx6ullevk/mx6ullevk.c
+++ b/board/freescale/mx6ullevk/mx6ullevk.c
@@ -127,6 +127,11 @@ int dram_init(void)
 {
 	gd->ram_size = imx_ddr_size();
 
+	/* Subtract the defined OPTEE runtime firmware length */
+#ifdef CONFIG_OPTEE_TZDRAM_SIZE
+	gd->ram_size -= CONFIG_OPTEE_TZDRAM_SIZE;
+#endif
+
 	return 0;
 }
 

--- a/common/spl/Kconfig
+++ b/common/spl/Kconfig
@@ -113,15 +113,6 @@ config SPL_FSL_PBL
 	  Create boot binary having SPL binary in PBI format concatenated with
 	  u-boot binary.
 
-config SPL_ALLOC_BD
-	bool "Allocate memory for bd_info"
-	default y if X86 || SANDBOX
-	help
-	  Some boards don't allocate space for this in their board_init_f()
-	  code. In this case U-Boot can allocate space for gd->bd in the
-	  standard SPL flow (board_init_r()). Enable this option to support
-	  this feature.
-
 endmenu
 
 config HANDOFF

--- a/common/spl/spl.c
+++ b/common/spl/spl.c
@@ -54,6 +54,9 @@ binman_sym_declare(ulong, spl, image_pos);
 binman_sym_declare(ulong, spl, size);
 #endif
 
+/* Define board data structure */
+static struct bd_info bdata __attribute__ ((section(".data")));
+
 /*
  * Board-specific Platform code can reimplement show_boot_progress () if needed
  */
@@ -455,19 +458,14 @@ static int spl_common_init(bool setup_malloc)
 	return 0;
 }
 
-int spl_alloc_bd(void)
+void spl_set_bd(void)
 {
 	/*
 	 * NOTE: On some platforms (e.g. x86) bdata may be in flash and not
 	 * writeable.
 	 */
-	if (!gd->bd) {
-		gd->bd = malloc(sizeof(*gd->bd));
-		if (!gd->bd)
-			return -ENOMEM;
-	}
-
-	return 0;
+	if (!gd->bd)
+		gd->bd = &bdata;
 }
 
 int spl_early_init(void)
@@ -617,6 +615,8 @@ void board_init_r(gd_t *dummy1, ulong dummy2)
 
 	debug(">>" SPL_TPL_PROMPT "board_init_r()\n");
 
+	spl_set_bd();
+
 #if defined(CONFIG_SYS_SPL_MALLOC_START)
 	mem_malloc_init(CONFIG_SYS_SPL_MALLOC_START,
 			CONFIG_SYS_SPL_MALLOC_SIZE);
@@ -625,10 +625,6 @@ void board_init_r(gd_t *dummy1, ulong dummy2)
 	if (!(gd->flags & GD_FLG_SPL_INIT)) {
 		if (spl_init())
 			hang();
-	}
-	if (IS_ENABLED(CONFIG_SPL_ALLOC_BD) && spl_alloc_bd()) {
-		puts("Cannot alloc bd\n");
-		hang();
 	}
 #if !defined(CONFIG_PPC) && !defined(CONFIG_ARCH_MX6)
 	/*

--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -286,7 +286,18 @@ static int _fastboot_parts_load_from_ptable(void)
 	ptable[PTN_BOOTLOADER_SECONDARY_INDEX].start = CONFIG_SECONDARY_BOOT_SECTOR_OFFSET +
 		ptable[PTN_BOOTLOADER_INDEX].start;
 	ptable[PTN_BOOTLOADER_SECONDARY_INDEX].length = ptable[PTN_BOOTLOADER_INDEX].length;
-	ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = boot_partition;
+	/*
+	 * From 5.8.2.2.1 High Level eMMC Boot Flow Note:
+	 * For the eMMC boot scenarios where the images are located in the boot partition
+	 * the boot image set selection is done based on BOOT_PARTITION_ENABLE eMMC ECSD register values,
+	 * which means that secondary boot image set should be flashed to boot1 partition to the
+	 * same offset the primary one
+	 */
+	if (is_imx8qm() || is_imx8qxp()) {
+		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
+	} else {
+		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = boot_partition;
+	}
 	ptable[PTN_BOOTLOADER_SECONDARY_INDEX].flags = FASTBOOT_PTENTRY_FLAGS_UNERASEABLE;
 	strcpy(ptable[PTN_BOOTLOADER_SECONDARY_INDEX].fstype, "raw");
 
@@ -306,7 +317,18 @@ static int _fastboot_parts_load_from_ptable(void)
 	strcpy(ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].name, FASTBOOT_PARTITION_BOOTLOADER2_SECONDARY);
 	ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].start = CONFIG_SECONDARY_BOOT_SECTOR_OFFSET + ptable[PTN_BOOTLOADER2_INDEX].start;
 	ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].length = ptable[PTN_BOOTLOADER2_INDEX].length;
-	ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = boot_partition;
+	/*
+	 * From 5.8.2.2.1 High Level eMMC Boot Flow Note:
+	 * For the eMMC boot scenarios where the images are located in the boot partition
+	 * the boot image set selection is done based on BOOT_PARTITION_ENABLE eMMC ECSD register values,
+	 * which means that secondary boot image set should be flashed to boot1 partition to the
+	 * same offset the primary one
+	 */
+	if (is_imx8qm() || is_imx8qxp()) {
+		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
+	} else {
+		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = boot_partition;
+	}
 	ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].flags = FASTBOOT_PTENTRY_FLAGS_UNERASEABLE;
 	strcpy(ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].fstype, "raw");
 	last_bootloader_partition = PTN_BOOTLOADER2_SECONDARY_INDEX;

--- a/include/configs/apalis-imx8.h
+++ b/include/configs/apalis-imx8.h
@@ -71,12 +71,16 @@
 	"m4boot_0=run loadm4image_0; dcache flush; bootaux ${loadaddr} 0\0" \
 	"m4boot_1=run loadm4image_1; dcache flush; bootaux ${loadaddr} 1\0" \
 
+#ifdef CONFIG_DISTRO_DEFAULTS
 #define BOOT_TARGET_DEVICES(func) \
 	func(MMC, mmc, 1) \
 	func(MMC, mmc, 2) \
 	func(MMC, mmc, 0) \
 	func(USB, usb, 0)
 #include <config_distro_bootcmd.h>
+#else
+#define BOOTENV ""
+#endif
 
 #ifdef CONFIG_AHAB_BOOT
 #define AHAB_ENV "sec_boot=yes\0"

--- a/include/configs/mx6ullevk.h
+++ b/include/configs/mx6ullevk.h
@@ -86,7 +86,6 @@
 	TEE_ENV \
 	"splashimage=0x8c000000\0" \
 	"fdt_addr=0x83000000\0" \
-	"fdt_high=0xffffffff\0"	  \
 	"tee_addr=0x84000000\0" \
 	"console=ttymxc0\0" \
 	"bootargs=console=ttymxc0,115200 ubi.mtd=nandrootfs "  \
@@ -110,7 +109,6 @@
 	"script=boot.scr\0" \
 	"image=zImage\0" \
 	"console=ttymxc0\0" \
-	"fdt_high=0xffffffff\0" \
 	"initrd_high=0xffffffff\0" \
 	"fdt_file=undefined\0" \
 	"fdt_addr=0x83000000\0" \
@@ -234,6 +232,7 @@
 #endif /* CONFIG_SPL_BUILD */
 
 /* Miscellaneous configurable options */
+#define CONFIG_SYS_BOOTMAPSZ           (256 << 20)
 
 #define CONFIG_SYS_LOAD_ADDR		CONFIG_LOADADDR
 #define CONFIG_SYS_HZ			1000

--- a/include/spl.h
+++ b/include/spl.h
@@ -352,15 +352,7 @@ u32 spl_mmc_boot_mode(const u32 boot_device);
  * If not overridden, it is weakly defined in common/spl/spl_mmc.c.
  */
 int spl_mmc_boot_partition(const u32 boot_device);
-
-/**
- * spl_alloc_bd() - Allocate space for bd_info
- *
- * This sets up the gd->bd pointer by allocating memory for it
- *
- * @return 0 if OK, -ENOMEM if out of memory
- */
-int spl_alloc_bd(void);
+void spl_set_bd(void);
 
 /**
  * spl_set_header_raw_uboot() - Set up a standard SPL image structure

--- a/tools/fit_image.c
+++ b/tools/fit_image.c
@@ -200,7 +200,7 @@ static void get_basename(char *str, int size, const char *fname)
 static void add_crc_node(void *fdt)
 {
 	fdt_begin_node(fdt, "hash-1");
-	fdt_property_string(fdt, FIT_ALGO_PROP, "crc32");
+	fdt_property_string(fdt, FIT_ALGO_PROP, "sha256");
 	fdt_end_node(fdt);
 }
 


### PR DESCRIPTION
Fixes for:
- building apalis-imx6[-sec];
- building apalis-imx8;
- starting SPL on apalis-imx6;
- starting OP-TEE and u-boot on imx6ull-evk.

- the latest backports from 2020.04
