### PR TITLE
xilinx-2021.07: Replace loading FPGA auth images with the latest patchset

### DIFF
--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -921,8 +921,9 @@ config CMD_FPGA_LOADP
 	  a partial bitstream.
 
 config CMD_FPGA_LOAD_SECURE
-	bool "fpga loads - loads secure bitstreams (Xilinx only)"
+	bool "fpga loads - loads secure bitstreams"
 	depends on CMD_FPGA
+	select FPGA_LOAD_SECURE
 	help
 	  Enables the fpga loads command which is used to load secure
 	  (authenticated or encrypted or both) bitstreams on to FPGA.

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -921,9 +921,8 @@ config CMD_FPGA_LOADP
 	  a partial bitstream.
 
 config CMD_FPGA_LOAD_SECURE
-	bool "fpga loads - loads secure bitstreams"
+	bool "fpga loads - loads secure bitstreams (Xilinx only)"
 	depends on CMD_FPGA
-	select FPGA_LOAD_SECURE
 	help
 	  Enables the fpga loads command which is used to load secure
 	  (authenticated or encrypted or both) bitstreams on to FPGA.

--- a/cmd/Kconfig
+++ b/cmd/Kconfig
@@ -928,15 +928,6 @@ config CMD_FPGA_LOAD_SECURE
 	  Enables the fpga loads command which is used to load secure
 	  (authenticated or encrypted or both) bitstreams on to FPGA.
 
-config CMD_SPL_FPGA_LOAD_SECURE
-	bool "fpga loads - loads secure bitstreams for SPL"
-	depends on CMD_FPGA && CMD_SPL
-	select SPL_FPGA_LOAD_SECURE
-	help
-	  Enables the fpga loads command which is used to load secure
-	  (authenticated or encrypted or both) bitstreams on to FPGA from
-	  SPL.
-
 config CMD_FPGAD
 	bool "fpgad - dump FPGA registers"
 	help

--- a/cmd/fpga.c
+++ b/cmd/fpga.c
@@ -178,7 +178,7 @@ static int do_fpga_load(struct cmd_tbl *cmdtp, int flag, int argc,
 	if (ret)
 		return ret;
 
-	return fpga_load(dev, (void *)fpga_data, data_size, BIT_FULL, NULL);
+	return fpga_load(dev, (void *)fpga_data, data_size, BIT_FULL);
 }
 
 static int do_fpga_loadb(struct cmd_tbl *cmdtp, int flag, int argc,
@@ -209,7 +209,7 @@ static int do_fpga_loadp(struct cmd_tbl *cmdtp, int flag, int argc,
 	if (ret)
 		return ret;
 
-	return fpga_load(dev, (void *)fpga_data, data_size, BIT_PARTIAL, NULL);
+	return fpga_load(dev, (void *)fpga_data, data_size, BIT_PARTIAL);
 }
 #endif
 
@@ -315,7 +315,7 @@ static int do_fpga_loadmk(struct cmd_tbl *cmdtp, int flag, int argc,
 			data_size = image_get_data_size(hdr);
 		}
 		return fpga_load(dev, (void *)data, data_size,
-				  BIT_FULL, NULL);
+				  BIT_FULL);
 	}
 #endif
 #if defined(CONFIG_FIT)
@@ -369,7 +369,7 @@ static int do_fpga_loadmk(struct cmd_tbl *cmdtp, int flag, int argc,
 			return CMD_RET_FAILURE;
 		}
 
-		return fpga_load(dev, fit_data, data_size, BIT_FULL, NULL);
+		return fpga_load(dev, fit_data, data_size, BIT_FULL);
 	}
 #endif
 	default:

--- a/cmd/fpga.c
+++ b/cmd/fpga.c
@@ -67,7 +67,7 @@ static int do_fpga_check_params(long *dev, long *fpga_data, size_t *data_size,
 	return 0;
 }
 
-#if CONFIG_IS_ENABLED(CMD_FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 int do_fpga_loads(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
 {
 	size_t data_size = 0;
@@ -396,7 +396,7 @@ static struct cmd_tbl fpga_commands[] = {
 #if defined(CONFIG_CMD_FPGA_LOADMK)
 	U_BOOT_CMD_MKENT(loadmk, 2, 1, do_fpga_loadmk, "", ""),
 #endif
-#if CONFIG_IS_ENABLED(CMD_FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 	U_BOOT_CMD_MKENT(loads, 6, 1, do_fpga_loads, "", ""),
 #endif
 };
@@ -430,7 +430,7 @@ static int do_fpga_wrapper(struct cmd_tbl *cmdtp, int flag, int argc,
 	return cmd_process_error(fpga_cmd, ret);
 }
 
-#if defined(CONFIG_CMD_FPGA_LOADFS) || CONFIG_IS_ENABLED(CMD_FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOADFS) || defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 U_BOOT_CMD(fpga, 9, 1, do_fpga_wrapper,
 #else
 U_BOOT_CMD(fpga, 6, 1, do_fpga_wrapper,
@@ -465,7 +465,7 @@ U_BOOT_CMD(fpga, 6, 1, do_fpga_wrapper,
 	   "\tsubimage unit name in the form of addr:<subimg_uname>"
 #endif
 #endif
-#if CONFIG_IS_ENABLED(CMD_FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 	   "Load encrypted bitstream (Xilinx only)\n"
 	   "  loads [dev] [address] [size] [auth-OCM-0/DDR-1/noauth-2]\n"
 	   "        [enc-devkey(0)/userkey(1)/nenc(2) [Userkey address]\n"

--- a/common/Kconfig.boot
+++ b/common/Kconfig.boot
@@ -218,8 +218,8 @@ config SPL_LOAD_FIT
 	  1. "loadables" images, other than FDTs, which do not have a "load"
 	     property will not be loaded. This limitation also applies to FPGA
 	     images with the correct "compatible" string.
-	  2. For FPGA images, only the "compatible" = "u-boot,fpga-legacy"
-	     loading method is supported.
+	  2. For FPGA images, the supported "compatible" list is in the
+	     doc/uImage.FIT/source_file_format.txt.
 	  3. FDTs are only loaded for images with an "os" property of "u-boot".
 	     "linux" images are also supported with Falcon boot mode.
 

--- a/common/image.c
+++ b/common/image.c
@@ -1514,14 +1514,14 @@ int boot_get_fpga(int argc, char *const argv[], bootm_headers_t *images,
 						 img_len, BIT_FULL);
 			if (err)
 				err = fpga_load(devnum, (const void *)img_data,
-						img_len, BIT_FULL, NULL);
+						img_len, BIT_FULL);
 		} else {
 			name = "partial";
 			err = fpga_loadbitstream(devnum, (char *)img_data,
 						 img_len, BIT_PARTIAL);
 			if (err)
 				err = fpga_load(devnum, (const void *)img_data,
-						img_len, BIT_PARTIAL, NULL);
+						img_len, BIT_PARTIAL);
 		}
 
 		if (err)

--- a/common/spl/spl_fit.c
+++ b/common/spl/spl_fit.c
@@ -573,11 +573,9 @@ static int spl_fit_upload_fpga(struct spl_fit_info *ctx, int node,
 	compatible = fdt_getprop(ctx->fit, node, "compatible", NULL);
 	if (!compatible)
 		warn_deprecated("'fpga' image without 'compatible' property");
-	else if (strcmp(compatible, "u-boot,fpga-legacy"))
-		printf("Ignoring compatible = %s property\n", compatible);
 
-	ret = fpga_load(0, (void *)fpga_image->load_addr, fpga_image->size,
-			BIT_FULL);
+	ret = fit_fpga_load(0, (void *)fpga_image->load_addr, fpga_image->size,
+			    BIT_FULL, compatible);
 	if (ret) {
 		printf("%s: Cannot load the image to the FPGA\n", __func__);
 		return ret;

--- a/common/spl/spl_fit.c
+++ b/common/spl/spl_fit.c
@@ -573,9 +573,11 @@ static int spl_fit_upload_fpga(struct spl_fit_info *ctx, int node,
 	compatible = fdt_getprop(ctx->fit, node, "compatible", NULL);
 	if (!compatible)
 		warn_deprecated("'fpga' image without 'compatible' property");
+	else if (strcmp(compatible, "u-boot,fpga-legacy"))
+		printf("Ignoring compatible = %s property\n", compatible);
 
 	ret = fpga_load(0, (void *)fpga_image->load_addr, fpga_image->size,
-			BIT_FULL, compatible);
+			BIT_FULL);
 	if (ret) {
 		printf("%s: Cannot load the image to the FPGA\n", __func__);
 		return ret;

--- a/doc/uImage.FIT/source_file_format.txt
+++ b/doc/uImage.FIT/source_file_format.txt
@@ -184,7 +184,10 @@ the '/images' node should have the following layout:
     Mandatory for types: "firmware", and "kernel".
   - compatible : compatible method for loading image.
     Mandatory for types: "fpga", and images that do not specify a load address.
-    To use the generic fpga loading routine, use "u-boot,fpga-legacy".
+    Supported compatible methods:
+    "u-boot,fpga-legacy" - the generic fpga loading routine.
+    "u-boot,zynqmp-fpga-ddrauth" - signed non-encrypted FPGA bitstream for
+    Xilinx Zynq UltraScale+ (ZymqMP) device.
 
   Optional nodes:
   - hash-1 : Each hash sub-node represents separate hash or checksum

--- a/drivers/fpga/Kconfig
+++ b/drivers/fpga/Kconfig
@@ -85,4 +85,18 @@ config FPGA_ZYNQPL
 	  Enable FPGA driver for loading bitstream in BIT and BIN format
 	  on Xilinx Zynq devices.
 
+config FPGA_LOAD_SECURE
+	bool "Enable loading secure bitstreams"
+	depends on FPGA
+	help
+	  Enables the fpga loads() functions that are used to load secure
+	  (authenticated or encrypted or both) bitstreams on to FPGA.
+
+config SPL_FPGA_LOAD_SECURE
+	bool "Enable loading secure bitstreams for SPL"
+	depends on FPGA
+	help
+	  Enables the fpga loads() functions that are used to load secure
+	  (authenticated or encrypted or both) bitstreams on to FPGA.
+
 endmenu

--- a/drivers/fpga/Kconfig
+++ b/drivers/fpga/Kconfig
@@ -85,18 +85,4 @@ config FPGA_ZYNQPL
 	  Enable FPGA driver for loading bitstream in BIT and BIN format
 	  on Xilinx Zynq devices.
 
-config FPGA_LOAD_SECURE
-	bool "Enable loading secure bitstreams"
-	depends on FPGA
-	help
-	  Enables the fpga loads() functions that are used to load secure
-	  (authenticated or encrypted or both) bitstreams on to FPGA.
-
-config SPL_FPGA_LOAD_SECURE
-	bool "Enable loading secure bitstreams for SPL"
-	depends on FPGA
-	help
-	  Enables the fpga loads() functions that are used to load secure
-	  (authenticated or encrypted or both) bitstreams on to FPGA.
-
 endmenu

--- a/drivers/fpga/fpga.c
+++ b/drivers/fpga/fpga.c
@@ -220,7 +220,7 @@ int fpga_fsload(int devnum, const void *buf, size_t size,
 }
 #endif
 
-#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
+#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
 int fpga_loads(int devnum, const void *buf, size_t size,
 	       struct fpga_secure_info *fpga_sec_info)
 {

--- a/drivers/fpga/fpga.c
+++ b/drivers/fpga/fpga.c
@@ -277,8 +277,8 @@ int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype)
 		switch (desc->devtype) {
 		case fpga_xilinx:
 #if defined(CONFIG_FPGA_XILINX)
-			ret_val = xilinx_load(desc->devdesc, buf, bsize,
-					      bstype);
+			ret_val = xilinx_load((xilinx_desc **)&desc->devdesc,
+					      buf, bsize, bstype);
 #else
 			fpga_no_sup((char *)__func__, "Xilinx devices");
 #endif

--- a/drivers/fpga/fpga.c
+++ b/drivers/fpga/fpga.c
@@ -264,8 +264,6 @@ int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype,
 		switch (desc->devtype) {
 		case fpga_xilinx:
 #if defined(CONFIG_FPGA_XILINX)
-			((xilinx_desc *)desc->devdesc)->compatible =
-				(char *)compatible;
 			ret_val = xilinx_load(desc->devdesc, buf, bsize,
 					      bstype);
 #else

--- a/drivers/fpga/fpga.c
+++ b/drivers/fpga/fpga.c
@@ -250,11 +250,9 @@ int fpga_loads(int devnum, const void *buf, size_t size,
 #endif
 
 /*
- * Generic multiplexing code:
- * Each architecture must handle the mandatory FPGA DT compatible property.
+ * Generic multiplexing code
  */
-int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype,
-	      const char *compatible)
+int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype)
 {
 	int ret_val = FPGA_FAIL;           /* assume failure */
 	const fpga_desc *desc = fpga_validate(devnum, buf, bsize,
@@ -272,9 +270,6 @@ int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype,
 			break;
 		case fpga_altera:
 #if defined(CONFIG_FPGA_ALTERA)
-			if (strcmp(compatible, "u-boot,fpga-legacy"))
-				printf("Ignoring compatible = %s property\n",
-				       compatible);
 			ret_val = altera_load(desc->devdesc, buf, bsize);
 #else
 			fpga_no_sup((char *)__func__, "Altera devices");
@@ -282,9 +277,6 @@ int fpga_load(int devnum, const void *buf, size_t bsize, bitstream_type bstype,
 			break;
 		case fpga_lattice:
 #if defined(CONFIG_FPGA_LATTICE)
-			if (strcmp(compatible, "u-boot,fpga-legacy"))
-				printf("Ignoring compatible = %s property\n",
-				       compatible);
 			ret_val = lattice_load(desc->devdesc, buf, bsize);
 #else
 			fpga_no_sup((char *)__func__, "Lattice devices");

--- a/drivers/fpga/fpga.c
+++ b/drivers/fpga/fpga.c
@@ -220,7 +220,7 @@ int fpga_fsload(int devnum, const void *buf, size_t size,
 }
 #endif
 
-#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 int fpga_loads(int devnum, const void *buf, size_t size,
 	       struct fpga_secure_info *fpga_sec_info)
 {

--- a/drivers/fpga/spartan2.c
+++ b/drivers/fpga/spartan2.c
@@ -40,10 +40,11 @@ static int spartan2_ss_dump(xilinx_desc *desc, const void *buf, size_t bsize);
 
 /* ------------------------------------------------------------------------- */
 /* Spartan-II Generic Implementation */
-static int spartan2_load(xilinx_desc *desc, const void *buf, size_t bsize,
+static int spartan2_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 			 bitstream_type bstype)
 {
 	int ret_val = FPGA_FAIL;
+	xilinx_desc *desc = *desc_ptr;
 
 	switch (desc->iface) {
 	case slave_serial:

--- a/drivers/fpga/spartan3.c
+++ b/drivers/fpga/spartan3.c
@@ -44,10 +44,11 @@ static int spartan3_ss_dump(xilinx_desc *desc, const void *buf, size_t bsize);
 
 /* ------------------------------------------------------------------------- */
 /* Spartan-II Generic Implementation */
-static int spartan3_load(xilinx_desc *desc, const void *buf, size_t bsize,
+static int spartan3_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 			 bitstream_type bstype)
 {
 	int ret_val = FPGA_FAIL;
+	xilinx_desc *desc = *desc_ptr;
 
 	switch (desc->iface) {
 	case slave_serial:

--- a/drivers/fpga/versalpl.c
+++ b/drivers/fpga/versalpl.c
@@ -26,7 +26,7 @@ static ulong versal_align_dma_buffer(ulong *buf, u32 len)
 	return (ulong)buf;
 }
 
-static int versal_load(xilinx_desc *desc, const void *buf, size_t bsize,
+static int versal_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 		       bitstream_type bstype)
 {
 	ulong bin_buf;

--- a/drivers/fpga/virtex2.c
+++ b/drivers/fpga/virtex2.c
@@ -93,10 +93,11 @@ static int virtex2_ssm_dump(xilinx_desc *desc, const void *buf, size_t bsize);
 static int virtex2_ss_load(xilinx_desc *desc, const void *buf, size_t bsize);
 static int virtex2_ss_dump(xilinx_desc *desc, const void *buf, size_t bsize);
 
-static int virtex2_load(xilinx_desc *desc, const void *buf, size_t bsize,
+static int virtex2_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 			bitstream_type bstype)
 {
 	int ret_val = FPGA_FAIL;
+	xilinx_desc *desc = *desc_ptr;
 
 	switch (desc->iface) {
 	case slave_serial:

--- a/drivers/fpga/xilinx.c
+++ b/drivers/fpga/xilinx.c
@@ -172,7 +172,7 @@ int xilinx_loadfs(xilinx_desc *desc, const void *buf, size_t bsize,
 }
 #endif
 
-#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
+#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
 int xilinx_loads(xilinx_desc *desc, const void *buf, size_t bsize,
 		 struct fpga_secure_info *fpga_sec_info)
 {

--- a/drivers/fpga/xilinx.c
+++ b/drivers/fpga/xilinx.c
@@ -138,9 +138,11 @@ int fpga_loadbitstream(int devnum, char *fpgadata, size_t size,
 	return fpga_load(devnum, dataptr, swapsize, bstype);
 }
 
-int xilinx_load(xilinx_desc *desc, const void *buf, size_t bsize,
+int xilinx_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 		bitstream_type bstype)
 {
+	xilinx_desc *desc = *desc_ptr;
+
 	if (!xilinx_validate (desc, (char *)__FUNCTION__)) {
 		printf ("%s: Invalid device descriptor\n", __FUNCTION__);
 		return FPGA_FAIL;

--- a/drivers/fpga/xilinx.c
+++ b/drivers/fpga/xilinx.c
@@ -153,7 +153,7 @@ int xilinx_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 		return FPGA_FAIL;
 	}
 
-	return desc->operations->load(desc, buf, bsize, bstype);
+	return desc->operations->load(desc_ptr, buf, bsize, bstype);
 }
 
 #if defined(CONFIG_CMD_FPGA_LOADFS)

--- a/drivers/fpga/xilinx.c
+++ b/drivers/fpga/xilinx.c
@@ -135,7 +135,7 @@ int fpga_loadbitstream(int devnum, char *fpgadata, size_t size,
 	dataptr += 4;
 	printf("  bytes in bitstream = %d\n", swapsize);
 
-	return fpga_load(devnum, dataptr, swapsize, bstype, NULL);
+	return fpga_load(devnum, dataptr, swapsize, bstype);
 }
 
 int xilinx_load(xilinx_desc *desc, const void *buf, size_t bsize,

--- a/drivers/fpga/xilinx.c
+++ b/drivers/fpga/xilinx.c
@@ -172,7 +172,7 @@ int xilinx_loadfs(xilinx_desc *desc, const void *buf, size_t bsize,
 }
 #endif
 
-#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE)
 int xilinx_loads(xilinx_desc *desc, const void *buf, size_t bsize,
 		 struct fpga_secure_info *fpga_sec_info)
 {

--- a/drivers/fpga/zynqmppl.c
+++ b/drivers/fpga/zynqmppl.c
@@ -245,7 +245,7 @@ static int zynqmp_load(xilinx_desc *desc, const void *buf, size_t bsize,
 	return ret;
 }
 
-#if defined(CONFIG_CMD_FPGA_LOAD_SECURE) && !defined(CONFIG_SPL_BUILD)
+#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
 static int zynqmp_loads(xilinx_desc *desc, const void *buf, size_t bsize,
 			struct fpga_secure_info *fpga_sec_info)
 {
@@ -306,7 +306,7 @@ static int zynqmp_pcap_info(xilinx_desc *desc)
 
 struct xilinx_fpga_op zynqmp_op = {
 	.load = zynqmp_load,
-#if defined(CONFIG_CMD_FPGA_LOAD_SECURE) && !defined(CONFIG_SPL_BUILD)
+#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
 	.loads = zynqmp_loads,
 #endif
 	.info = zynqmp_pcap_info,

--- a/drivers/fpga/zynqmppl.c
+++ b/drivers/fpga/zynqmppl.c
@@ -199,8 +199,8 @@ static int zynqmp_validate_bitstream(xilinx_desc *desc, const void *buf,
 	return 0;
 }
 
-static int zynqmp_load(xilinx_desc *desc, const void *buf, size_t bsize,
-		     bitstream_type bstype)
+static int zynqmp_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
+		       bitstream_type bstype)
 {
 	ALLOC_CACHE_ALIGN_BUFFER(u32, bsizeptr, 1);
 	u32 swap = 0;
@@ -209,6 +209,7 @@ static int zynqmp_load(xilinx_desc *desc, const void *buf, size_t bsize,
 	u32 buf_lo, buf_hi;
 	u32 ret_payload[PAYLOAD_ARG_CNT];
 	bool xilfpga_old = false;
+	xilinx_desc *desc = *desc_ptr;
 
 	if (zynqmp_firmware_version() <= PMUFW_V1_0) {
 		puts("WARN: PMUFW v1.0 or less is detected\n");

--- a/drivers/fpga/zynqmppl.c
+++ b/drivers/fpga/zynqmppl.c
@@ -210,25 +210,6 @@ static int zynqmp_load(xilinx_desc *desc, const void *buf, size_t bsize,
 	u32 ret_payload[PAYLOAD_ARG_CNT];
 	bool xilfpga_old = false;
 
-	if (desc->compatible &&
-	    !strcmp(desc->compatible, "u-boot,zynqmp-fpga-ddrauth")) {
-#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
-		struct fpga_secure_info info = { 0 };
-
-		if (!desc->operations->loads) {
-			printf("%s: Missing load operation\n", __func__);
-			return FPGA_FAIL;
-		}
-		/* DDR authentication */
-		info.authflag = 1;
-		info.encflag = 2;
-		return desc->operations->loads(desc, buf, bsize, &info);
-#else
-		printf("No support for %s\n", desc->compatible);
-		return FPGA_FAIL;
-#endif
-	}
-
 	if (zynqmp_firmware_version() <= PMUFW_V1_0) {
 		puts("WARN: PMUFW v1.0 or less is detected\n");
 		puts("WARN: Not all bitstream formats are supported\n");

--- a/drivers/fpga/zynqmppl.c
+++ b/drivers/fpga/zynqmppl.c
@@ -245,7 +245,7 @@ static int zynqmp_load(xilinx_desc *desc, const void *buf, size_t bsize,
 	return ret;
 }
 
-#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE) && !defined(CONFIG_SPL_BUILD)
 static int zynqmp_loads(xilinx_desc *desc, const void *buf, size_t bsize,
 			struct fpga_secure_info *fpga_sec_info)
 {
@@ -306,7 +306,7 @@ static int zynqmp_pcap_info(xilinx_desc *desc)
 
 struct xilinx_fpga_op zynqmp_op = {
 	.load = zynqmp_load,
-#if CONFIG_IS_ENABLED(FPGA_LOAD_SECURE)
+#if defined(CONFIG_CMD_FPGA_LOAD_SECURE) && !defined(CONFIG_SPL_BUILD)
 	.loads = zynqmp_loads,
 #endif
 	.info = zynqmp_pcap_info,

--- a/drivers/fpga/zynqpl.c
+++ b/drivers/fpga/zynqpl.c
@@ -370,11 +370,12 @@ static int zynq_validate_bitstream(xilinx_desc *desc, const void *buf,
 	return 0;
 }
 
-static int zynq_load(xilinx_desc *desc, const void *buf, size_t bsize,
+static int zynq_load(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 		     bitstream_type bstype)
 {
 	unsigned long ts; /* Timestamp */
 	u32 isr_status, swap;
+	xilinx_desc *desc = *desc_ptr;
 
 	/*
 	 * send bsize inplace of blocksize as it was not a bitstream

--- a/include/fpga.h
+++ b/include/fpga.h
@@ -35,6 +35,7 @@ typedef enum {			/* typedef fpga_type */
 typedef struct {		/* typedef fpga_desc */
 	fpga_type devtype;	/* switch value to select sub-functions */
 	void *devdesc;		/* real device descriptor */
+	char *compatible;	/* device compatible string */
 } fpga_desc;			/* end, typedef fpga_desc */
 
 typedef struct {                /* typedef fpga_desc */
@@ -63,6 +64,9 @@ int fpga_add(fpga_type devtype, void *desc);
 int fpga_count(void);
 const fpga_desc *const fpga_get_desc(int devnum);
 int fpga_is_partial_data(int devnum, size_t img_len);
+/* the DT compatible property must be handled by the different FPGA archs */
+int fit_fpga_load(int devnum, const void *buf, size_t bsize,
+		  bitstream_type bstype, const char *compatible);
 int fpga_load(int devnum, const void *buf, size_t bsize,
 	      bitstream_type bstype);
 int fpga_fsload(int devnum, const void *buf, size_t size,

--- a/include/fpga.h
+++ b/include/fpga.h
@@ -63,9 +63,8 @@ int fpga_add(fpga_type devtype, void *desc);
 int fpga_count(void);
 const fpga_desc *const fpga_get_desc(int devnum);
 int fpga_is_partial_data(int devnum, size_t img_len);
-/* the DT compatible property must be handled by the different FPGA archs */
 int fpga_load(int devnum, const void *buf, size_t bsize,
-	      bitstream_type bstype, const char *compatible);
+	      bitstream_type bstype);
 int fpga_fsload(int devnum, const void *buf, size_t size,
 		fpga_fs_info *fpga_fsinfo);
 int fpga_loads(int devnum, const void *buf, size_t size,

--- a/include/xilinx.h
+++ b/include/xilinx.h
@@ -48,12 +48,14 @@ typedef struct {		/* typedef xilinx_desc */
 } xilinx_desc;			/* end, typedef xilinx_desc */
 
 struct xilinx_fpga_op {
-	int (*load)(xilinx_desc *, const void *, size_t, bitstream_type);
-	int (*loadfs)(xilinx_desc *, const void *, size_t, fpga_fs_info *);
+	int (*load)(xilinx_desc *desc, const void *buf, size_t bsize,
+		    bitstream_type bstype);
+	int (*loadfs)(xilinx_desc *desc, const void *buf, size_t bsize,
+		      fpga_fs_info *fpga_fsinfo);
 	int (*loads)(xilinx_desc *desc, const void *buf, size_t bsize,
 		     struct fpga_secure_info *fpga_sec_info);
-	int (*dump)(xilinx_desc *, const void *, size_t);
-	int (*info)(xilinx_desc *);
+	int (*dump)(xilinx_desc *desc, const void *buf, size_t bsize);
+	int (*info)(xilinx_desc *desc);
 };
 
 /* Generic Xilinx Functions

--- a/include/xilinx.h
+++ b/include/xilinx.h
@@ -58,7 +58,7 @@ struct xilinx_fpga_op {
 
 /* Generic Xilinx Functions
  *********************************************************************/
-int xilinx_load(xilinx_desc *desc, const void *image, size_t size,
+int xilinx_load(xilinx_desc **desc_ptr, const void *image, size_t size,
 		bitstream_type bstype);
 int xilinx_dump(xilinx_desc *desc, const void *buf, size_t bsize);
 int xilinx_info(xilinx_desc *desc);

--- a/include/xilinx.h
+++ b/include/xilinx.h
@@ -48,7 +48,7 @@ typedef struct {		/* typedef xilinx_desc */
 } xilinx_desc;			/* end, typedef xilinx_desc */
 
 struct xilinx_fpga_op {
-	int (*load)(xilinx_desc *desc, const void *buf, size_t bsize,
+	int (*load)(xilinx_desc **desc_ptr, const void *buf, size_t bsize,
 		    bitstream_type bstype);
 	int (*loadfs)(xilinx_desc *desc, const void *buf, size_t bsize,
 		      fpga_fs_info *fpga_fsinfo);

--- a/include/xilinx.h
+++ b/include/xilinx.h
@@ -45,7 +45,6 @@ typedef struct {		/* typedef xilinx_desc */
 	int cookie;		/* implementation specific cookie */
 	struct xilinx_fpga_op *operations; /* operations */
 	char *name;		/* device name in bitstream */
-	char *compatible;	/* fdt compatible string */
 } xilinx_desc;			/* end, typedef xilinx_desc */
 
 struct xilinx_fpga_op {


### PR DESCRIPTION
This patchset introduces support for the authenticated FPGA images
on ZynqMP boards, besides that introducing common way to pass the
compatible property to any fpga driver.
  
It bases on the initial work by Jorge Ramirez-Ortiz <jorge@founries.io>
  https://patchwork.ozlabs.org/project/uboot/patch/20211015091506.2602-1-jorge@foundries.io/
  https://patchwork.ozlabs.org/project/uboot/patch/20211005111324.19749-3-jorge@foundries.io/
  
**Changes in v5:**

- replace ifdef with if() where it's possible
  
**Changes in v4:**  

- change interface to xilinx_desc->operations->open() callback.
- fix a bug from previous version of the patchset in dereferencing of a parent fpga_desc structure.
  
**Changes in v3:**

- remove the patch which introduced CMD_SPL_FPGA_LOAD_SECURE.
- fix mixing definitions/declarations.
- replace strcmp() calls with more secure strncmp().
- document the "u-boot,zynqmp-fpga-ddrauth" compatible string.
- fix code style by check-patch recommendations.
  
**Changes in v2:**

- add function fit_fpga_load() to simplify calls of fpga_load() from contexts without a compatible attribute.
- move all ZynqMP-specific logic to drivers/fpga/zynqmppl.c
- prepare for passing a "compatible" FDT property to any fpga driver.