### PR TITLE
[FIO toup] apalis-imx8: allow dropping CONFIG_CMD_USB requirement

### DIFF
--- a/include/configs/apalis-imx8.h
+++ b/include/configs/apalis-imx8.h
@@ -97,12 +97,16 @@
 	"m4boot_0=run loadm4image_0; dcache flush; bootaux ${loadaddr} 0\0" \
 	"m4boot_1=run loadm4image_1; dcache flush; bootaux ${loadaddr} 1\0" \
 
+#ifdef CONFIG_DISTRO_DEFAULTS
 #define BOOT_TARGET_DEVICES(func) \
 	func(MMC, mmc, 1) \
 	func(MMC, mmc, 2) \
 	func(MMC, mmc, 0) \
 	func(USB, usb, 0)
 #include <config_distro_bootcmd.h>
+#else
+#define BOOTENV ""
+#endif
 
 #ifdef CONFIG_AHAB_BOOT
 #define AHAB_ENV "sec_boot=yes\0"


### PR DESCRIPTION
When CONFIG_DISTRO_DEFAULTS is not defined, don't include
config_distro_bootcmd.h. This will break the build based
on the stock defines:
        func(MMC, mmc, 1) \
        func(MMC, mmc, 2) \
        func(MMC, mmc, 0) \
        func(USB, usb, 0)

Signed-off-by: Michael Scott <mike@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
