### PR TITLE
[FIO extras-squash] imx_env: fix set mfg to run fastboot by default

### DIFF
--- a/include/configs/imx_env.h
+++ b/include/configs/imx_env.h
@@ -33,7 +33,9 @@
 		"rdinit=/linuxrc " \
 		"clk_ignore_unused "\
 		"\0" \
-	MFG_NAND_FIT_PARTITION \
+	"bootcmd_mfg=run mfgtool_args;" \
 	FASTBOOT_CMD \
+	"\0" \
+	MFG_NAND_FIT_PARTITION \
 
 #endif


### PR DESCRIPTION
This fixes commit 6e15126624 ("[FIO extras] imx_env: set mfg to run
fastboot by default").

The original commit accidentally removed the needed env var from
CONFIG_MFG_ENV_SETTINGS_DEFAULT:
   "bootcmd_mfg=run mfgtool_args;" \
and it doesn't make sure to add a NUL character to the end of
FASTBOOT_CMD.

This causes a default environment to look like this:
    "mfgtool_args=setenv bootargs console=${console},${baudrate} " \
        "rdinit=/linuxrc " \
        "clk_ignore_unused "\
        "\0" \
    "echo \"Run fastboot ...\"; fastboot 0; " \

The result of this, is the NEXT variable defined in
include/configs/<board>.h gets eaten.

In many cases, this is the initrd_addr variable:
	CONFIG_MFG_ENV_SETTINGS_DEFAULT \
	"initrd_addr=0x43800000\0" \
	"initrd_high=0xffffffffffffffff\0" \
	"emmc_dev=2\0"\
	"sd_dev=1\0" \

The default environment looks like this:
    "mfgtool_args=setenv bootargs console=${console},${baudrate} " \
        "rdinit=/linuxrc " \
        "clk_ignore_unused "\
        "\0" \
    "echo \"Run fastboot ...\"; fastboot 0; initrd_addr=0x43800000\0" \
    "initrd_high=0xffffffffffffffff\0" \
    "emmc_dev=2\0"\
    "sd_dev=1\0" \

Fixup the original commit to avoid this.

Signed-off-by: Michael Scott <mike@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
