### PR TITLE
[FIO internal] fiovb: support for boot firmware update variables

### DIFF
--- a/include/tee/optee_ta_fiovb.h
+++ b/include/tee/optee_ta_fiovb.h
@@ -8,8 +8,10 @@
 #define TA_FIOVB_UUID {0x22250a54, 0x0bf1, 0x48fe, \
 		      { 0x80, 0x02, 0x7b, 0x20, 0xf1, 0xc9, 0xc9, 0xb1 } }
 
-#define PERSIST_VALUE_LIST {"bootcount", "upgrade_available", "rollback", \
-			    "m4hash", "m4size"}
+#define PERSIST_VALUE_LIST {"bootcount", "bootupgrade_available", \
+			    "bootupgrade_primary_updated", \
+			    "upgrade_available", \
+			    "rollback", "m4hash", "m4size"}
 
 /*
  * Reads a persistent value corresponding to the given name.


### PR DESCRIPTION
Introduce two additional variables needed for handling boot firmware
updates: bootupgrade_available and bootupgrade_primary_updated.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
