### PR TITLE
2021.04: apalis-imx8: fixes

### DIFF
--- a/include/configs/apalis-imx8.h
+++ b/include/configs/apalis-imx8.h
@@ -102,7 +102,7 @@
 	"image=Image\0" \
 	"console=ttyLP1 earlycon\0" \
 	"fdt_addr=0x83000000\0"	\
-	"fdt_high=\0" \
+	"fdt_high=0xffffffffffffffff\0" \
 	"boot_fdt=try\0" \
 	"fdtfile=" FDT_FILE "\0" \
 	"finduuid=part uuid mmc ${mmcdev}:2 uuid\0" \

--- a/include/configs/apalis-imx8.h
+++ b/include/configs/apalis-imx8.h
@@ -56,11 +56,26 @@
 #define CONFIG_NETMASK			255.255.255.0
 #define CONFIG_SERVERIP			192.168.10.1
 
+/**
+ * SYS_SDRAM_BASE	0x80000000	0.125MiB
+ * SYS_TEXT_BASE	0x80020000	2.375MiB
+ * kernel_addr_r	0x80280000	45.5MiB
+ * fdt_addr_r		0x83000000	1MiB
+ * scriptaddr		0x83100000	15MiB
+ * __RESERVED__		0x84000000	48MiB
+ * loadaddr		0x87000000	48MiB
+ * ramdisk_addr_r	0x8a000000	288MiB (to hdp_addr)
+ * SYS_MEMTEST_START	0x90000000
+ * hdp_addr		0x9c000000
+ * SYS_MEMTEST_END	0xC0000000
+ */
 #define MEM_LAYOUT_ENV_SETTINGS \
-	"fdt_addr_r=0x84000000\0" \
-	"kernel_addr_r=0x82000000\0" \
-	"ramdisk_addr_r=0x86400000\0" \
-	"scriptaddr=0x87000000\0"
+	"fdt_addr_r=0x83000000\0" \
+	"hdp_addr=0x9c000000\0" \
+	"initrd_addr=0x83800000\0" \
+	"kernel_addr_r=0x80280000\0" \
+	"ramdisk_addr_r=0x8a000000\0" \
+	"scriptaddr=0x83100000\0"
 
 /* Boot M4 */
 #define M4_BOOT_ENV \
@@ -88,8 +103,8 @@
 #define AHAB_ENV "sec_boot=no\0"
 #endif
 
-#define FDT_FILE			"fsl-imx8qm-apalis-v1.1-eval.dtb"
-#define FDT_FILE_V1_0			"fsl-imx8qm-apalis-eval.dtb"
+#define FDT_FILE			"imx8qm-apalis-v1.1-eval.dtb"
+#define FDT_FILE_V1_0			"imx8qm-apalis-eval.dtb"
 
 /* Initial environment variables */
 #define CONFIG_EXTRA_ENV_SETTINGS \
@@ -101,13 +116,10 @@
 	"script=boot.scr\0" \
 	"image=Image\0" \
 	"console=ttyLP1 earlycon\0" \
-	"fdt_addr=0x83000000\0"	\
 	"fdt_high=0xffffffffffffffff\0" \
 	"boot_fdt=try\0" \
 	"fdtfile=" FDT_FILE "\0" \
 	"finduuid=part uuid mmc ${mmcdev}:2 uuid\0" \
-	"initrd_addr=0x83800000\0" \
-	"hdp_addr=0x84000000\0" \
 	"hdp_file=hdmitxfw.bin\0" \
 	"loadhdp=fatload mmc ${mmcdev}:${mmcpart} ${hdp_addr} ${hdp_file}\0" \
 	"mmcautodetect=yes\0" \
@@ -118,8 +130,8 @@
 	"netargs=setenv bootargs console=${console},${baudrate} " \
 		"root=/dev/nfs ip=dhcp nfsroot=${serverip}:${nfsroot},v3,tcp" \
 		"\0" \
-	"nfsboot=run netargs; dhcp ${loadaddr} ${image}; tftp ${fdt_addr} " \
-		"apalis-imx8/${fdt_file}; booti ${loadaddr} - ${fdt_addr}\0" \
+	"nfsboot=run netargs; dhcp ${loadaddr} ${image}; tftp ${fdt_addr_r} " \
+		"apalis-imx8/${fdtfile}; booti ${loadaddr} - ${fdt_addr_r}\0" \
 	"panel=NULL\0" \
 	"update_uboot=askenv confirm Did you load u-boot-dtb.imx (y/N)?; " \
 		"if test \"$confirm\" = \"y\"; then " \
@@ -131,7 +143,7 @@
 	"defargs=pci=nomsi"
 
 /* Link Definitions */
-#define CONFIG_LOADADDR			0x80280000
+#define CONFIG_LOADADDR			0x87000000
 
 #define CONFIG_SYS_LOAD_ADDR		CONFIG_LOADADDR
 


### PR DESCRIPTION
- fix fdt relocation
- fix script load address and forwardport a memory layout from 2020.04

Tested on: `Model: Toradex Apalis iMX8 QuadMax 4GB IT V1.1B, Serial# 06675393`

```
U-Boot SPL 2021.04+fio+gc41a81870f (Dec 08 2021 - 16:30:09 +0000)
...
SPL: Booting primary boot path: using 0x400 offset for next boot image
## Checking hash(es) for config config-1 ... sha256,rsa2048:ubootdev+ OK
## Checking hash(es) for Image atf ... sha256+ OK
## Checking hash(es) for Image uboot ... sha256+ OK
## Checking hash(es) for Image ubootfdt ... sha256+ OK
## Checking hash(es) for Image optee ... sha256+ OK
## Checking hash(es) for Image bootscr ... sha256+ OK
I/TC: 
I/TC: Non-secure external DT found
I/TC: OP-TEE version: 3.10.0-117-gd3aabed77 (gcc version 10.2.0 (GCC)) #1 Wed 17 Nov 2021 12:34:46 AM UTC aarch64
...
U-Boot 2021.04+fio+gc41a81870f (Dec 08 2021 - 16:30:09 +0000)

CPU:   NXP i.MX8QM RevB A53 at 1200 MHz at 52C

DRAM:  4 GiB
...
## Executing script at 83100000
sha256,rsa2048:ubootdev+ sha256+ Using freescale_imx8qm-apalis-ixora-v1.1.dtb
446 bytes read in 2 ms (217.8 KiB/s)
...
## Copying 'loadable-hdmitxfw.bin' subimage from FIT image at 8a000000 ...
sha256,rsa2048:ubootdev+ sha256+    Loading part 0 ... OK
Loading hdp firmware from 0x0000000087000000 offset 0x0000000000002000
Loading hdp firmware Complete
...
## Loading kernel from FIT Image at 8a000000 ...
   Using 'conf-freescale_imx8qm-apalis-ixora-v1.1.dtb' configuration
   Verifying Hash Integrity ... sha256,rsa2048:ubootdev+ OK
...
Welcome to Linux-microPlatform 3.3.4-60-82-137-gc12c437!
```
