### PR TITLE
2021.04+imx 5.10.35 2.0.0-fio: fix for imx8mp-evk

### DIFF
--- a/common/Kconfig
+++ b/common/Kconfig
@@ -738,7 +738,7 @@ source "common/spl/Kconfig"
 
 config IMAGE_SIGN_INFO
 	bool
-	select SHA1
+	select SHA1 if !FIT_SIGNATURE_STRICT
 	select SHA256
 	help
 	  Enable image_sign_info helper functions.
@@ -747,7 +747,7 @@ if IMAGE_SIGN_INFO
 
 config SPL_IMAGE_SIGN_INFO
 	bool
-	select SHA1
+	select SPL_SHA1 if !SPL_FIT_SIGNATURE_STRICT
 	select SHA256
 	help
 	  Enable image_sign_info helper functions in SPL.

--- a/common/Kconfig.boot
+++ b/common/Kconfig.boot
@@ -11,10 +11,10 @@ config ANDROID_BOOT_IMAGE
 
 config FIT
 	bool "Support Flattened Image Tree"
-	select MD5 if (!SPL_BUILD && !FIT_SIGNATURE_STRICT) || \
-		      (SPL_BUILD && !SPL_FIT_SIGNATURE_STRICT)
-	select SHA1 if (!SPL_BUILD && !FIT_SIGNATURE_STRICT) || \
-		       (SPL_BUILD && !SPL_FIT_SIGNATURE_STRICT)
+	select MD5 if (!SPL_BUILD && !FIT_SIGNATURE_STRICT)
+	select SPL_MD5 if (SPL_BUILD && !SPL_FIT_SIGNATURE_STRICT)
+	select SHA1 if (!SPL_BUILD && !FIT_SIGNATURE_STRICT)
+	select SPL_SHA1 if (SPL_BUILD && !SPL_FIT_SIGNATURE_STRICT)
 	help
 	  This option allows you to boot the new uImage structure,
 	  Flattened Image Tree.  FIT is formally a FDT, which can include

--- a/common/hash.c
+++ b/common/hash.c
@@ -41,7 +41,9 @@ DECLARE_GLOBAL_DATA_PTR;
 
 static void reloc_update(void);
 
-#if defined(CONFIG_SHA1) && !defined(CONFIG_SHA_PROG_HW_ACCEL)
+#if ((defined(CONFIG_SHA1) && !defined(CONFIG_SPL_BUILD)) || \
+     (defined(CONFIG_SPL_SHA1) && defined(CONFIG_SPL_BUILD))) && \
+     !defined(CONFIG_SHA_PROG_HW_ACCEL)
 static int hash_init_sha1(struct hash_algo *algo, void **ctxp)
 {
 	sha1_context *ctx = malloc(sizeof(sha1_context));
@@ -217,7 +219,8 @@ static int hash_finish_crc32(struct hash_algo *algo, void *ctx, void *dest_buf,
  * Note that algorithm names must be in lower case.
  */
 static struct hash_algo hash_algo[] = {
-#ifdef CONFIG_SHA1
+#if (defined(CONFIG_SHA1) && !defined(CONFIG_SPL_BUILD)) || \
+    (defined(CONFIG_SPL_SHA1) && defined(CONFIG_SPL_BUILD))
 	{
 		.name 		= "sha1",
 		.digest_size	= SHA1_SUM_LEN,

--- a/common/spl/Kconfig
+++ b/common/spl/Kconfig
@@ -418,7 +418,7 @@ config SPL_MD5_SUPPORT
 config SPL_SHA1_SUPPORT
 	bool "Support SHA1"
 	depends on SPL_FIT && !SPL_FIT_SIGNATURE_STRICT
-	select SHA1
+	select SPL_SHA1
 	help
 	  Enable this to support SHA1 in FIT images within SPL. A SHA1
 	  checksum is a 160-bit (20-byte) hash value used to check that the
@@ -497,7 +497,7 @@ config SPL_CRYPTO_SUPPORT
 
 config SPL_HASH_SUPPORT
 	bool "Support hashing drivers"
-	select SHA1 if !SPL_FIT_SIGNATURE_STRICT
+	select SPL_SHA1 if !SPL_FIT_SIGNATURE_STRICT
 	select SHA256
 	help
 	  Enable hashing drivers in SPL. These drivers can be used to
@@ -508,13 +508,13 @@ config SPL_HASH_SUPPORT
 config TPL_HASH_SUPPORT
 	bool "Support hashing drivers in TPL"
 	depends on TPL
-	select SHA1 if !SPL_FIT_SIGNATURE_STRICT
+	select SPL_SHA1 if !SPL_FIT_SIGNATURE_STRICT
 	select SHA256
 	help
-	  Enable hashing drivers in SPL. These drivers can be used to
+	  Enable hashing drivers in TPL. These drivers can be used to
 	  accelerate secure boot processing in secure applications. Enable
 	  this option to build system-specific drivers for hash acceleration
-	  as part of an SPL build.
+	  as part of a TPL build.
 
 config SPL_DMA
 	bool "Support DMA drivers"

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -389,6 +389,14 @@ config SHA1
 	  The SHA1 algorithm produces a 160-bit (20-byte) hash value
 	  (digest).
 
+config SPL_SHA1
+	bool "Enable SHA1 support in SPL"
+	help
+	  This option enables support of hashing using SHA1 algorithm
+	  in SPL. The hash is calculated in software.
+	  The SHA1 algorithm produces a 160-bit (20-byte) hash value
+	  (digest).
+
 config SHA256
 	bool "Enable SHA256 support"
 	help

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -62,7 +62,7 @@ obj-$(CONFIG_$(SPL_)ACPIGEN) += acpi/
 obj-$(CONFIG_$(SPL_)MD5) += md5.o
 obj-$(CONFIG_$(SPL_)RSA) += rsa/
 obj-$(CONFIG_HASH) += hash-checksum.o
-obj-$(CONFIG_SHA1) += sha1.o
+obj-$(CONFIG_$(SPL_TPL_)SHA1) += sha1.o
 obj-$(CONFIG_SHA256) += sha256.o
 obj-$(CONFIG_SHA512_ALGO) += sha512.o
 

--- a/lib/tpm-v1.c
+++ b/lib/tpm-v1.c
@@ -17,7 +17,7 @@
 
 #ifdef CONFIG_TPM_AUTH_SESSIONS
 
-#ifndef CONFIG_SHA1
+#if !CONFIG_IS_ENABLED(SHA1)
 #error "TPM_AUTH_SESSIONS require SHA1 to be configured, too"
 #endif /* !CONFIG_SHA1 */
 


### PR DESCRIPTION
- fix for imx8mp-evk (reduce SPL size for making able to turn on strict fit signatures)