### PR TITLE
Zynqmp SPI boot image offsets

### DIFF
--- a/arch/arm/mach-zynqmp/Kconfig
+++ b/arch/arm/mach-zynqmp/Kconfig
@@ -24,6 +24,22 @@ config SPL_SPI_FLASH_SUPPORT
 config SPL_SPI_SUPPORT
 	default y if ZYNQ_QSPI
 
+config SYS_SPI_BOOT_IMAGE_OFFS
+	default 0x0
+	hex "address of primary boot image in SPI flash"
+	depends on SPL_SPI_LOAD
+	help
+	  Address within SPI-Flash from where the primary boot image
+	  is fetched from by BootROM. Must be a multiple of 32Kb (0x8000).
+
+config SYS_SPI_BOOT_IMAGE_OFFS2
+	default 0x50000
+	hex "address of secondary boot image in SPI flash"
+	depends on SPL_SPI_LOAD
+	help
+	  Address within SPI-Flash from where the secondary boot image
+	  is fetched from by BootROM. Must be a multiple of 32Kb (0x8000).
+
 config SYS_SPI_U_BOOT_OFFS2
 	default 0xaa0000
 	hex "address of secondary u-boot payload in SPI flash"

--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -413,6 +413,22 @@ static int do_multi_boot(struct cmd_tbl *cmdtp, int flag,
 		printf("Incorrect value of multiboot offset\n");
 		return CMD_RET_USAGE;
 	}
+#if defined(CONFIG_SPL_SPI_SUPPORT)
+	if (!strcmp(env_get("modeboot"), "qspiboot")) {
+		u32 boot_image_offset = golden_image_boundary * multiboot;
+
+		if (boot_image_offset != CONFIG_SYS_SPI_BOOT_IMAGE_OFFS &&
+		    boot_image_offset != CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2) {
+			printf("Invalid value of multiboot register"
+			       "supported values are: %d, %d\n",
+			       (CONFIG_SYS_SPI_BOOT_IMAGE_OFFS /
+				golden_image_boundary),
+			       (CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2 /
+				golden_image_boundary));
+			return CMD_RET_FAILURE;
+		}
+	}
+#endif
 
 	printf("Set multiboot offset to: \t%d\n", multiboot);
 

--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -52,6 +52,14 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
+/*
+ * Golden image boundary:
+ * Boot images can be located every 32 KB in the boot memory device,
+ * which allows for more than one boot image to be in the memory
+ * device.
+ */
+const u32 golden_image_boundary = 0x8000;
+
 #if CONFIG_IS_ENABLED(FPGA) && defined(CONFIG_FPGA_ZYNQMPPL)
 static xilinx_desc zynqmppl = XILINX_ZYNQMP_DESC;
 
@@ -971,31 +979,31 @@ unsigned int spl_spi_get_uboot_offs(struct spi_flash *flash)
 {
 	int ret;
 	u32 multiboot;
-	u32 spi_offset = 0;
+	u32 payload_offset = 0;
+	u32 boot_image_offset = 0x0;
 
 	multiboot = multi_boot_get();
+	boot_image_offset = golden_image_boundary * multiboot;
 
 	/*
+	 * Default values are:
 	 * Primary boot.bin offset   - 0x0 (multiboot == 0)
 	 * Secondary boot.bin offset - 0x50000 (multiboot == 10,
 	 *                             as 10 * 32KB == 0x50000)
 	 */
-	switch(multiboot) {
-	case 0:
-		spi_offset = CONFIG_SYS_SPI_U_BOOT_OFFS;
-		break;
-	case 10:
-		spi_offset = CONFIG_SYS_SPI_U_BOOT_OFFS2;
-		break;
-	default:
+	if (boot_image_offset == CONFIG_SYS_SPI_BOOT_IMAGE_OFFS) {
+		payload_offset = CONFIG_SYS_SPI_U_BOOT_OFFS;
+	} else if (boot_image_offset == CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2) {
+		payload_offset = CONFIG_SYS_SPI_U_BOOT_OFFS2;
+	} else {
 		printf("Invalid value of multiboot register, value = %d\n",
 		       multiboot);
 		hang();
-		break;
 	}
 
-	printf("SPL: Booting next image from 0x%x SPI offset\n", spi_offset);
+	printf("SPL: Booting next image from 0x%x SPI offset\n",
+	       payload_offset);
 
-	return spi_offset;
+	return payload_offset;
 }
 #endif


### PR DESCRIPTION
Introduce SYS_SPI_BOOT_IMAGE_OFFS/SYS_SPI_BOOT_IMAGE_OFFS2 Kconfig
options that provide possibility to adjust spi boot image layout.

Add additional check to multi_boot cmd implementation, so it permits to set
values of multiboot offset register that correspond to
SYS_SPI_BOOT_IMAGE_OFFS/SYS_SPI_BOOT_IMAGE_OFFS2.