### PR TITLE
[FIO internal] ARM: dts: imx8qm-apalis: add optee firmware node

### DIFF
--- a/arch/arm/dts/fsl-imx8qm-apalis-u-boot.dtsi
+++ b/arch/arm/dts/fsl-imx8qm-apalis-u-boot.dtsi
@@ -22,6 +22,14 @@
 		status = "okay";
 		u-boot,dm-spl;
 	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+			rpmb-dev = <&usdhc1>;
+		};
+	};
 };
 
 &{/imx8qm-pm} {


### PR DESCRIPTION
Add OP-TEE firmware node needed for fiovb.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
