### PR TITLE
[FIO internal] cmd: fiovb: increase fiovb_name buffer

### DIFF
--- a/cmd/fiovb.c
+++ b/cmd/fiovb.c
@@ -11,6 +11,8 @@
 #include <mmc.h>
 #include <fiovb.h>
 
+#define FIOVB_NAME_LEN	40
+
 static struct fiovb_ops *fiovb_ops;
 
 int do_fiovb_init(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
@@ -45,7 +47,7 @@ int do_fiovb_read_pvalue(cmd_tbl_t *cmdtp, int flag, int argc,
 	size_t bytes_read;
 	void *buffer;
 	char *endp;
-	char fiovb_name[30] = { 0 }; /* fiovb.name */
+	char fiovb_name[FIOVB_NAME_LEN] = { 0 }; /* fiovb.name */
 	char fiovb_val[32] = { 0 };
 
 	if (!fiovb_ops) {
@@ -89,7 +91,7 @@ int do_fiovb_write_pvalue(cmd_tbl_t *cmdtp, int flag, int argc,
 {
 	const char *name;
 	const char *value;
-	char fiovb_name[30] = { 0 }; /* fiovb.name */
+	char fiovb_name[FIOVB_NAME_LEN] = { 0 }; /* fiovb.name */
 
 	if (!fiovb_ops) {
 		printf("Foundries.IO Verified Boot is not initialized, run 'fiovb init' first\n");
@@ -120,7 +122,7 @@ int do_fiovb_delete_pvalue(cmd_tbl_t *cmdtp, int flag, int argc,
 			   char * const argv[])
 {
 	const char *name;
-	char fiovb_name[30] = { 0 }; /* fiovb.name */
+	char fiovb_name[FIOVB_NAME_LEN] = { 0 }; /* fiovb.name */
 
 	if (!fiovb_ops) {
 		printf("Foundries.IO Verified Boot is not initialized, run 'fiovb init' first\n");


### PR DESCRIPTION
The alternative boot path includes a new variable, bootupgrade_primary_updated,
that overflows the previous buffer length for the fiovb exported env variable,
so increase the fiovb_name buffer.

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
