### PR TITLE
zynqmp: rename SPI_SUPPORT symbol

### DIFF
--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -430,7 +430,7 @@ static int do_multi_boot(struct cmd_tbl *cmdtp, int flag,
 		printf("Incorrect value of multiboot offset\n");
 		return CMD_RET_USAGE;
 	}
-#if defined(CONFIG_SPL_SPI_SUPPORT)
+#if defined(CONFIG_SPL_SPI)
 	if (!strcmp(env_get("modeboot"), "qspiboot")) {
 		u32 boot_image_offset = golden_image_boundary * multiboot;
 
@@ -1032,7 +1032,7 @@ void set_dfu_alt_info(char *interface, char *devstr)
 }
 #endif
 
-#if defined(CONFIG_SPL_SPI_SUPPORT)
+#if defined(CONFIG_SPL_SPI)
 unsigned int spl_spi_get_uboot_offs(struct spi_flash *flash)
 {
 	int ret;


### PR DESCRIPTION
Since ea2ca7e17ec("spi: Rename SPI_SUPPORT to SPI") SPI_SUPPORT os not
valid anymore, use new one instead.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
