### PR TITLE
[FIO internal] arch: arm: mach-imx: fiohab: extend hab event message

### DIFF
--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -192,6 +192,7 @@ static int hab_status(void)
 		       HAB_SUCCESS) {
 			if (!is_known_rng_fail_event(event_data, bytes)) {
 				printf("HAB events active error\n");
+				printf("Make sure the SPL is correctly signed and the board is fused\n");
 				return 1;
 			}
 		}
@@ -200,6 +201,7 @@ static int hab_status(void)
 		return 0;
 #else
 		printf("HAB events active error\n");
+		printf("Make sure the SPL is correctly signed and the board is fused\n");
 		return 1;
 #endif
 	}


### PR DESCRIPTION
In case of any hab events found in the image, print a message to help
with the most common errors (SPL incorrectly signed or board not
fused).

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
