### PR TITLE
[FIO fromtree] imx8m: drivers/ddr: Change padding of DDR4 and LPDDR4 …

### DIFF
--- a/drivers/ddr/imx/imx8m/helper.c
+++ b/drivers/ddr/imx/imx8m/helper.c
@@ -18,8 +18,8 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 #define IMEM_LEN 32768 /* byte */
-#define DMEM_LEN 16384 /* byte */
-#define IMEM_2D_OFFSET	49152
+#define DMEM_LEN 4096  /* byte */
+#define IMEM_2D_OFFSET	36864
 
 #define IMEM_OFFSET_ADDR 0x00050000
 #define DMEM_OFFSET_ADDR 0x00054000


### PR DESCRIPTION
…DMEM firmware

DMEM firmware files are padded to 16KB, wasting precious space
in processor internal RAM (TMU). The actual size of these files
is less than 2KB, so padding them to 4KB is sufficient.

This patch changes the expected size of DMEM firmware.
It relies on boot image creation tools to generate 4KB padding.

Signed-off-by: Felix Radensky <felix.r@variscite.com>
Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
