### PR TITLE
[RFC] [FIO toup] arm: imx: don't use CAAM if optee enabled

### DIFF
--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -1,5 +1,6 @@
 config HAS_CAAM
 	bool
+	depends on !OPTEE
 
 config IMX_CONFIG
 	string

--- a/arch/arm/mach-imx/imx8/Kconfig
+++ b/arch/arm/mach-imx/imx8/Kconfig
@@ -20,7 +20,7 @@ config IMX_LOAD_HDMI_FIMRWARE_TX
 
 config IMX8
 	bool
-	select HAS_CAAM if !OPTEE
+	imply HAS_CAAM
 
 config MU_BASE_SPL
 	hex "MU base address used in SPL"

--- a/arch/arm/mach-imx/imx8m/Kconfig
+++ b/arch/arm/mach-imx/imx8m/Kconfig
@@ -2,7 +2,7 @@ if ARCH_IMX8M
 
 config IMX8M
 	bool
-	select HAS_CAAM if !OPTEE
+	imply HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
 
 config IMX8MQ

--- a/arch/arm/mach-imx/mx6/Kconfig
+++ b/arch/arm/mach-imx/mx6/Kconfig
@@ -20,39 +20,39 @@ choice
 
 config MX6D
 	bool "i.MX 6Dual SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select MX6_SMP
 
 config MX6DL
 	bool "i.MX 6DualLite SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select MX6_SMP
 
 config MX6Q
 	bool "i.MX 6Quad SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select MX6_SMP
 
 config MX6QP
 	bool "i.MX 6QuadPlus SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select MX6_SMP
 
 config MX6QDL
 	bool "i.MX 6Dual and 6Quad SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select MX6_SMP
 
 config MX6S
 	bool "i.MX 6Solo SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 
 config MX6SL
 	bool "i.MX 6SoloLite SoC support"
 
 config MX6SX
 	bool "i.MX 6SoloX SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
 
 config MX6SLL
@@ -61,7 +61,7 @@ config MX6SLL
 
 config MX6UL
 	bool "i.MX 6UltraLite SoC support"
-	select HAS_CAAM
+	imply HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
 	select SYSCOUNTER_TIMER
 	select SYS_L2CACHE_OFF

--- a/arch/arm/mach-imx/mx7/Kconfig
+++ b/arch/arm/mach-imx/mx7/Kconfig
@@ -12,7 +12,7 @@ config MX7
 
 config MX7D
 	bool
-	select HAS_CAAM
+	imply HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
 	imply CMD_FUSE
 

--- a/arch/arm/mach-imx/mx7ulp/Kconfig
+++ b/arch/arm/mach-imx/mx7ulp/Kconfig
@@ -9,7 +9,7 @@ config LDO_ENABLED_MODE
 	  Select this option to enable the PMC1 LDO.
 
 config MX7ULP
-	select HAS_CAAM if !OPTEE
+	imply HAS_CAAM
 	bool
 
 config IMX_M4_BIND


### PR DESCRIPTION
A general solution for disabling CAAM if OPTEE is used.

OP-TEE uses CAAM module. Keep CAAM disabled in u-boot if OP-TEE
enabled.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
