### PR TITLE
usb: dwc3: zynqmp: fix reset usb ULPI phy

### DIFF
--- a/drivers/usb/dwc3/dwc3-generic.c
+++ b/drivers/usb/dwc3/dwc3-generic.c
@@ -109,7 +109,7 @@ static int dwc3_generic_probe(struct udevice *dev,
 		return rc;
 
 	if (device_is_compatible(dev->parent, "xlnx,zynqmp-dwc3")) {
-		ret = gpio_request_by_name(dev->parent, "reset-gpios", 0,
+		ret = gpio_request_by_name(dev->parent, "reset-gpio", 0,
 					   &priv->ulpi_reset, GPIOD_ACTIVE_LOW);
 		if (ret != -EBUSY && ret)
 			return ret;


### PR DESCRIPTION
Fixes: 7cf60855c1b ("usb: dwc3: Add support to reset usb ULPI phy")

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

