### PR TITLE
ARM: dts: imx6-apalis: remove stub for memory layout

### DIFF
--- a/arch/arm/dts/imx6-apalis.dts
+++ b/arch/arm/dts/imx6-apalis.dts
@@ -11,12 +11,6 @@
 	model = "Toradex Apalis iMX6Q/D";
 	compatible = "toradex,apalis_imx6q", "fsl,imx6q";
 
-	/* Will be filled by the bootloader */
-	memory@10000000 {
-		device_type = "memory";
-		reg = <0x10000000 0>;
-	};
-
 	aliases {
 		mmc0 = &usdhc3;
 		mmc1 = &usdhc1;


### PR DESCRIPTION
This node is updated instead of being replaced in
fdt_fixup_memory_banks(). It causes crash in OP-TEE 3.15 by claiming
non-sec memory in sec area [1].
Remove the node "memory@10000000", it is still created and filled up
in a bootloader properly.

[1]
I/TC: Non-secure external DT found
E/TC:0 0 check_phys_mem_is_outside:345 Non-sec mem (0x10000000:0) overlaps map (type 2 0x4e000000:0x9b000)
E/TC:0 0 Panic at core/arch/arm/mm/core_mmu.c:349 <check_phys_mem_is_outside>
...

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
