### PR TITLE
[FIO toup] zynqmp: multi_boot cmd valid value check adjustments

### DIFF
--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -440,9 +440,10 @@ static int do_multi_boot(struct cmd_tbl *cmdtp, int flag,
 		u32 boot_image_offset = golden_image_boundary * multiboot;
 
 		if (boot_image_offset != CONFIG_SYS_SPI_BOOT_IMAGE_OFFS &&
-		    boot_image_offset != CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2) {
+		    boot_image_offset != CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2 &&
+		    boot_image_offset != 0) {
 			printf("Invalid value of multiboot register, "
-			       "supported values are: %d, %d\n",
+			       "supported values are: 0, %d, %d\n",
 			       (CONFIG_SYS_SPI_BOOT_IMAGE_OFFS /
 				golden_image_boundary),
 			       (CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2 /


### PR DESCRIPTION
Adjust additional check to multi_boot cmd implementation, that in case
of QSPI boot besides SYS_SPI_BOOT_IMAGE_OFFS/SYS_SPI_BOOT_IMAGE_OFFS2,
it permits to set 0 for the special case, when Image Selector is used.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
