### PR TITLE
drivers: tee: i2c: fix SE050 errata

### DIFF
--- a/drivers/tee/optee/Kconfig
+++ b/drivers/tee/optee/Kconfig
@@ -40,16 +40,15 @@ config OPTEE_TA_SCP03
 
 config TEE_I2C_NXP_SE05X_ERRATA
 	bool "Enable NXP SE05X Errata"
-       select TEE_I2C_NXP_SE05X_ERRATA_IN_BUS
 	default y
 	help
-         This config prevents the I2C trampoline driver from probing
-         on every transfer.
+	 This config prevents the I2C trampoline driver from probing
+	 on every transfer.
 
 config TEE_I2C_NXP_SE05X_ERRATA_IN_BUS
 	int "I2C bus where to apply the NXP SE05X errata"
-       depends on TEE_I2C_NXP_SE05X_ERRATA
-       default 0
+	depends on TEE_I2C_NXP_SE05X_ERRATA
+	default 0
 
 endmenu
 

--- a/drivers/tee/optee/i2c.c
+++ b/drivers/tee/optee/i2c.c
@@ -40,18 +40,18 @@ static struct udevice *get_chip_dev(int bnum, int addr)
 	struct udevice *chip;
 	struct udevice *bus;
 
-	if (IS_ENABLED(CONFIG_TEE_I2C_NXP_SE05X_ERRATA)) {
-		if (bnum == CONFIG_TEE_I2C_NXP_SE05X_ERRATA_IN_BUS &&
-		    addr == NXP_SE05X_ADDR) {
-			if (uclass_get_device_by_seq(UCLASS_I2C, bnum, &bus))
-				return NULL;
+#if defined(CONFIG_TEE_I2C_NXP_SE05X_ERRATA)
+	if (bnum == CONFIG_TEE_I2C_NXP_SE05X_ERRATA_IN_BUS &&
+	    addr == NXP_SE05X_ADDR) {
+		if (uclass_get_device_by_seq(UCLASS_I2C, bnum, &bus))
+			return NULL;
 
-			if (i2c_get_chip(bus, addr, 0, &chip))
-				return NULL;
+		if (i2c_get_chip(bus, addr, 0, &chip))
+			return NULL;
 
-			return chip;
-		}
+		return chip;
 	}
+#endif
 
 	if (i2c_get_chip_for_busnum(bnum, addr, 0, &chip))
 		return NULL;


### PR DESCRIPTION
Fix build issue when the feature is not selected

Fixes: 53fc827020 ("drivers: tee: i2c: support the NXP SE05x
                    probe errata")

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
