### PR TITLE
2022.04+lf 5.15.32 2.0.0-fio: fixes for 6ull and other boards

### DIFF
--- a/boot/image-sig.c
+++ b/boot/image-sig.c
@@ -17,7 +17,7 @@ DECLARE_GLOBAL_DATA_PTR;
 #define IMAGE_MAX_HASHED_NODES		100
 
 struct checksum_algo checksum_algos[] = {
-#if CONFIG_IS_ENABLED(FIT_SIGNATURE_STRICT)
+#if !CONFIG_IS_ENABLED(FIT_SIGNATURE_STRICT)
 	{
 		.name = "sha1",
 		.checksum_len = SHA1_SUM_LEN,

--- a/drivers/mmc/Kconfig
+++ b/drivers/mmc/Kconfig
@@ -45,6 +45,7 @@ config DM_MMC
 config SPL_DM_MMC
 	bool "Enable MMC controllers using Driver Model in SPL"
 	depends on SPL_DM && DM_MMC
+	select SPL_BLK
 	default y
 	help
 	  This enables the MultiMediaCard (MMC) uclass which supports MMC and

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -71,9 +71,9 @@ obj-$(CONFIG_ECDSA) += ecdsa/
 obj-$(CONFIG_$(SPL_)RSA) += rsa/
 obj-$(CONFIG_HASH) += hash-checksum.o
 obj-$(CONFIG_BLAKE2) += blake2/blake2b.o
-obj-$(CONFIG_SHA1) += sha1.o
-obj-$(CONFIG_SHA256) += sha256.o
-obj-$(CONFIG_SHA512) += sha512.o
+obj-$(CONFIG_$(SPL_)SHA1) += sha1.o
+obj-$(CONFIG_$(SPL_)SHA256) += sha256.o
+obj-$(CONFIG_$(SPL_)SHA512) += sha512.o
 obj-$(CONFIG_CRYPT_PW) += crypt/
 
 obj-$(CONFIG_$(SPL_)ZLIB) += zlib/


### PR DESCRIPTION
Fixed a regression bug and 2 bugs in upstream.

- 779e7a2267f [FIO toup] mmc: spl: select SPL_BLK for SPL_DM_MMC (Oleksandr Suvorov, 2 days ago)
- 24c450d340e [FIO toup] spl: crypto: fix including object files of SHA* in SPL (Oleksandr Suvorov, 3 days ago)
- cefdada6cf3 [FIO squash] image-sig: fix disabling SHA1 with FIT_SIGNATURE_STRICT (Oleksandr Suvorov, 3 days ago)
