### PR TITLE
boot: image-sig: fix using disabled SHA1

### DIFF
--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -101,7 +101,7 @@ config USE_IMXIMG_PLUGIN
 config IMX_HAB
 	bool "Support i.MX HAB features"
 	depends on ARCH_MX7 || ARCH_MX6 || ARCH_MX5 || ARCH_IMX8M || ARCH_MX7ULP
-	select FSL_CAAM if HAS_CAAM
+	imply FSL_CAAM if HAS_CAAM
 	imply CMD_PROVISION_KEY if HAS_CAAM
 	help
 	  This option enables the support for secure boot (HAB).

--- a/boot/image-sig.c
+++ b/boot/image-sig.c
@@ -17,7 +17,7 @@ DECLARE_GLOBAL_DATA_PTR;
 #define IMAGE_MAX_HASHED_NODES		100
 
 struct checksum_algo checksum_algos[] = {
-#if !CONFIG_IS_ENABLED(FIT_SIGNATURE_STRICT)
+#if CONFIG_IS_ENABLED(SHA1) && !CONFIG_IS_ENABLED(FIT_SIGNATURE_STRICT)
 	{
 		.name = "sha1",
 		.checksum_len = SHA1_SUM_LEN,


### PR DESCRIPTION
SHA1 can be disabled in either SPL or u-boot. Use the signature checking table entry for this algorithm only if [SPL_]SHA1 is enabled.

Fixes: e3e2acb5f31 ("[FIO extra] image-fit: dont use weak hash if SIGNATURE_STRICT")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>