### PR TITLE
[FIO squash] drivers: tee: i2c: fix format arguments size

### DIFF
--- a/drivers/tee/optee/i2c.c
+++ b/drivers/tee/optee/i2c.c
@@ -96,14 +96,14 @@ void optee_suppl_cmd_i2c_transfer(struct optee_msg_arg *arg)
 
 	switch (arg->params[0].u.value.a) {
 	case OPTEE_MSG_RPC_CMD_I2C_TRANSFER_RD:
-		log_debug("OPTEE_MSG_RPC_CMD_I2C_TRANSFER_RD %d\n",
+		log_debug("OPTEE_MSG_RPC_CMD_I2C_TRANSFER_RD %zd\n",
 			  (size_t)arg->params[2].u.rmem.size);
 
 		ret = dm_i2c_read(chip_dev, 0, buf,
 				  (size_t)arg->params[2].u.rmem.size);
 		break;
 	case OPTEE_MSG_RPC_CMD_I2C_TRANSFER_WR:
-		log_debug("OPTEE_MSG_RPC_CMD_I2C_TRANSFER_WR %d\n",
+		log_debug("OPTEE_MSG_RPC_CMD_I2C_TRANSFER_WR %zd\n",
 			  (size_t)arg->params[2].u.rmem.size);
 
 		ret = dm_i2c_write(chip_dev, 0, buf,


### PR DESCRIPTION
Backported from `2022.04+lf-5.15.52-2.1.0-fio`
size_t represents as %zd since C99.

Fixes: f855f77c2b1 ("[FIO fromlist] drivers: tee: i2c: support the NXP SE05x probe errata")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>