### PR TITLE
[FIO internal] fiohab: remove safeguard for incorrect rpmb key

### DIFF
--- a/arch/arm/mach-imx/fiohab.c
+++ b/arch/arm/mach-imx/fiohab.c
@@ -23,72 +23,6 @@
 #include <asm/arch/sci/sci.h>
 #endif
 
-#if defined(CONFIG_FIOVB) && !defined(CONFIG_SPL_BUILD)
-#include <fiovb.h>
-#include <mmc.h>
-
-static struct mmc *init_mmc_device(int dev, bool force_init)
-{
-	struct mmc *mmc;
-
-	mmc = find_mmc_device(dev);
-	if (!mmc) {
-		printf("no mmc device at slot %x\n", dev);
-		return NULL;
-	}
-
-	if (mmc_init(mmc)) {
-		printf("cant initialize mmc at slot %x\n", dev);
-		return NULL;
-	}
-
-	return mmc;
-}
-
-static int fiovb_provisioned(void)
-{
-	char len_str[32] = { '\0' };
-	struct fiovb_ops *sec;
-	int ret;
-	unsigned int fiohab_dev = env_get_ulong("fiohab_dev", 10, 0xFFUL);
-
-	if (fiohab_dev == 0xFFUL) {
-		printf("fiohab_dev var is not defined!\n");
-		return -EINVAL;
-	}
-
-	if (!init_mmc_device(fiohab_dev, false)) {
-		printf("Cant init MMC - RPMB not available\n");
-		return -1;
-	}
-
-	sec = fiovb_ops_alloc(fiohab_dev);
-	if (!sec) {
-		printf("Not enough memory to allocate ops\n");
-		return -ENOMEM;
-	}
-
-	snprintf(len_str, sizeof(len_str), "%ld", (unsigned long) 0);
-	ret = sec->write_persistent_value(sec, "m4size", strlen(len_str) + 1,
-					 (uint8_t *) len_str);
-	fiovb_ops_free(sec);
-
-	/* if the RPMB is accessible, then we can't close the device */
-	if (ret == FIOVB_IO_RESULT_OK) {
-		printf("Error, rpmb provisioned with test keys\n");
-		return -1;
-	}
-
-	return 0;
-}
-#else
-static int fiovb_provisioned(void)
-{
-	printf("RPMB provisioned check stubbed out !!\n");
-	return 0;
-}
-#endif
-
 #ifdef CONFIG_MX7ULP
 #define SRK_FUSE_LIST								\
 { 5, 0 }, { 5, 1 }, { 5, 2}, { 5, 3 }, { 5, 4 }, { 5, 5}, { 5, 6 }, { 5 ,7 },	\
@@ -213,10 +147,6 @@ static int hab_status(void)
 /* The fuses must have been programmed and their values set in the environment.
  * The fuse read operation returns a shadow value so a board reset is required
  * after the SRK fuses have been written.
- *
- * On CAAM enabled boards (imx7, imx6 and others), the board should not be closed
- * if RPMB keys have been provisioned as it would render it unavailable
- * afterwards
  */
 static int do_fiohab_close(struct cmd_tbl *cmdtp, int flag, int argc,
 			   char *const argv[])
@@ -239,11 +169,6 @@ static int do_fiohab_close(struct cmd_tbl *cmdtp, int flag, int argc,
 		printf("secure boot already enabled\n");
 		return 0;
 	}
-
-	/* if RPMB can be accessed, we cant close the board */
-	ret = fiovb_provisioned();
-	if (ret)
-		return 1;
 
 	/* if there are pending HAB errors, we cant close the board */
 	if (hab_status())


### PR DESCRIPTION
The initial check was done to cover cases in which the RPMB key is already burned (e.g. test keys), to block the close process as that would result in OP-TEE using the HUK-derived RPMB key instead.

This causes a few problems:
- Will not work on devices without eMMC/RPMB
- Can end up burning the wrong RPMB key (bugs in OP-TEE)
- Always cause a panic during the closing process

Remove as fusing shouldn't be blocked by the RPMB state.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
