### PR TITLE
[FIO internal] imx: imx8m: spl_mmc_emmc_boot_partition adjustment

### DIFF
--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -682,7 +682,8 @@ enum boot_device get_boot_device(void)
 }
 #endif
 
-#if defined(CONFIG_IMX8M)
+#if !defined(CONFIG_SECONDARY_BOOT_RUNTIME_DETECTION) && \
+    defined(CONFIG_IMX8M)
 #include <spl.h>
 int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 {


### PR DESCRIPTION
Don't rely on ROM event log during decision making what partition to boot when CONFIG_SECONDARY_BOOT_RUNTIME_DETECTION=y, as in this case SPL expects all images to be flashed to boot0.

Fixes: a5ee05cf("ARM: imx: Pick correct eMMC boot partition from ROM log")
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
