### PR TITLE
[FIO tosquash] fastboot: correctly fix build warning

### DIFF
--- a/drivers/fastboot/fb_fsl/fb_fsl_getvar.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_getvar.c
@@ -118,7 +118,7 @@ static bool is_slotvar(char *cmd)
 	return false;
 }
 
-#ifdef CONFIG_SERIAL_TAG
+#if defined(CONFIG_SERIAL_TAG) || defined(CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG)
 static char serial[IMX_SERIAL_LEN];
 #endif
 


### PR DESCRIPTION
serial usage depends on two configs, so make sure they are both covered at the variable declaration to avoid build failures.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
