### PR TITLE
imx8qm_mek: don't re-define CONFIG_SYS_MMC_ENV_DEV

### DIFF
--- a/include/configs/imx8qm_mek.h
+++ b/include/configs/imx8qm_mek.h
@@ -275,17 +275,19 @@
 	#define FDT_FILE	"fdt_file=undefined\0"
 #endif
 
+#if !defined(CONFIG_SYS_MMC_ENV_DEV)
 /* On LPDDR4 board, USDHC1 is for eMMC, USDHC2 is for SD on CPU board */
 #if defined(CONFIG_TARGET_IMX8QM_MEK_A72_ONLY)
 	#define CONFIG_SYS_MMC_ENV_DEV		0  /* USDHC1 */
-	#define CONFIG_MMCROOT			"/dev/mmcblk0p2"  /* USDHC1 */
 #elif defined(CONFIG_TARGET_IMX8QM_MEK_A53_ONLY)
 	#define CONFIG_SYS_MMC_ENV_DEV		1  /* USDHC2 */
-	#define CONFIG_MMCROOT			"/dev/mmcblk1p2"  /* USDHC2 */
 #else
 	#define CONFIG_SYS_MMC_ENV_DEV		1  /* USDHC2 */
-	#define CONFIG_MMCROOT			"/dev/mmcblk1p2"  /* USDHC2 */
 #endif
+#endif
+
+#define CONFIG_MMCROOT		"/dev/mmcblk" CONFIG_SYS_MMC_ENV_DEV "p2"
+
 #define CONFIG_SYS_FSL_USDHC_NUM	2
 
 #if defined(CONFIG_TARGET_IMX8QM_MEK_A72_ONLY)


### PR DESCRIPTION
Don't re-define CONFIG_SYS_MMC_ENV_DEV, if it's already set in defconfig.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
