### PR TITLE
[FIO tosquash] imx8qm_mek: fix build issues for CONFIG_MMCROOT

### DIFF
--- a/include/configs/imx8qm_mek.h
+++ b/include/configs/imx8qm_mek.h
@@ -286,7 +286,7 @@
 #endif
 #endif
 
-#define CONFIG_MMCROOT		"/dev/mmcblk" CONFIG_SYS_MMC_ENV_DEV "p2"
+#define CONFIG_MMCROOT		"/dev/mmcblk"__stringify(CONFIG_SYS_MMC_ENV_DEV)"p2"
 
 #define CONFIG_SYS_FSL_USDHC_NUM	2
 


### PR DESCRIPTION
Fix build issue, which is caused by appending a numeric constant to string literal. This fixes error:
 note: in expansion of macro 'CONFIG_SYS_MMC_ENV_DEV'
  289 | #define CONFIG_MMCROOT    "/dev/mmcblk" CONFIG_SYS_MMC_ENV_DEV "p2"
      |                                               ^~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
