### PR TITLE
[FIO totoradex] ARM: dts: fsl-imx8qm-apalis: adjust usdhc node pinctrls

### DIFF
--- a/arch/arm/dts/fsl-imx8qm-apalis.dts
+++ b/arch/arm/dts/fsl-imx8qm-apalis.dts
@@ -638,8 +638,10 @@
 
 /* eMMC */
 &usdhc1 {
-	pinctrl-names = "default";
+	pinctrl-names = "default", "state_100mhz", "state_200mhz";
 	pinctrl-0 = <&pinctrl_usdhc1>;
+	pinctrl-1 = <&pinctrl_usdhc1>;
+	pinctrl-2 = <&pinctrl_usdhc1>;
 	bus-width = <8>;
 	non-removable;
 	status = "okay";
@@ -647,8 +649,10 @@
 
 /* Apalis MMC1 */
 &usdhc2 {
-	pinctrl-names = "default";
+	pinctrl-names = "default", "state_100mhz", "state_200mhz";
 	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_mmc1_cd>;
+	pinctrl-1 = <&pinctrl_usdhc2>, <&pinctrl_mmc1_cd>;
+	pinctrl-2 = <&pinctrl_usdhc2>, <&pinctrl_mmc1_cd>;
 	bus-width = <8>;
 	cd-gpios = <&gpio2 9 GPIO_ACTIVE_LOW>; /* Apalis MMC1_CD# */
 	vmmc-supply = <&reg_usdhc2_vmmc>;
@@ -657,8 +661,10 @@
 
 /* Apalis SD1 */
 &usdhc3 {
-	pinctrl-names = "default";
+	pinctrl-names = "default", "state_100mhz", "state_200mhz";
 	pinctrl-0 = <&pinctrl_usdhc3>, <&pinctrl_sd1_cd>;
+	pinctrl-1 = <&pinctrl_usdhc3>, <&pinctrl_sd1_cd>;
+	pinctrl-2 = <&pinctrl_usdhc3>, <&pinctrl_sd1_cd>;
 	bus-width = <4>;
 	cd-gpios = <&gpio4 12 GPIO_ACTIVE_LOW>; /* Apalis SD1_CD# */
 	status = "okay";


### PR DESCRIPTION
Add additional "state_100mhz", "state_200mhz" pinctrl configurations, as fsl_esdhc_imx driver expects them to be defined in usdhc node. Use imx8qm-mek usdhc nodes as a reference.

This fixes such issues during MMC initialization:
esdhc_change_pinstate 10 error
esdhc_set_timing error -38
esdhc_change_pinstate 11 error
esdhc_set_timing error -38
Select HS400 failed -38
unable to select a mode : -5
MMC init failed

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
