### PR TITLE
[FIO internal] ARM: dts: fsl-imx8qm-apalis-u-boot: add optee node

### DIFF
--- a/arch/arm/dts/fsl-imx8qm-apalis-u-boot.dtsi
+++ b/arch/arm/dts/fsl-imx8qm-apalis-u-boot.dtsi
@@ -22,6 +22,14 @@
 		status = "okay";
 		u-boot,dm-spl;
 	};
+
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+			rpmb-dev = <&usdhc1>;
+		};
+	};
 };
 
 &{/imx8qm-pm} {


### PR DESCRIPTION
Add optee firmware node with rpmb-dev pointing to eMMC.

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
