### PR TITLE
[FIO tosquash] imx8: adjust address for FIT buffer

### DIFF
--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -349,7 +349,7 @@ void *board_spl_fit_buffer_addr(ulong fit_size, int sectors, int bl_len)
 		bl_len = 512;
 
 	if (is_imx8qm() || is_imx8qxp() || is_imx8dxl())
-		base_addr = 0x80280000;
+		base_addr = 0x83000000;
 	else
 		base_addr = CONFIG_SYS_TEXT_BASE;
 


### PR DESCRIPTION
Use different location for FIT image, as current one is not big enough and it overlaps with U-Boot image.

Fixes: 3c3b138ccd("[FIO internal] imx8: use different address for FIT buffer in board_spl_fit_buffer_addr()")
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
