### PR TITLE
[From tree] arm64: zynqmp: Print the secure boot status information

### DIFF
--- a/arch/arm/mach-zynqmp/include/mach/hardware.h
+++ b/arch/arm/mach-zynqmp/include/mach/hardware.h
@@ -152,6 +152,9 @@ struct apu_regs {
 #define CSU_JTAG_CHAIN_WR_SETUP		GENMASK(1, 0)
 #define CSU_PCAP_PROG_RELEASE_PL	BIT(0)
 
+#define ZYNQMP_CSU_STATUS_AUTHENTICATED	BIT(0)
+#define ZYNQMP_CSU_STATUS_ENCRYPTED	BIT(1)
+
 struct csu_regs {
 	u32 status;
 	u32 reserved0[3];

--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -396,6 +396,18 @@ static void restore_jtag(void)
 }
 #endif
 
+static void print_secure_boot(void)
+{
+	u32 status = 0;
+
+	if (zynqmp_mmio_read((ulong)&csu_base->status, &status))
+		return;
+
+	printf("Secure Boot:\t%sauthenticated, %sencrypted\n",
+	       status & ZYNQMP_CSU_STATUS_AUTHENTICATED ? "" : "not ",
+	       status & ZYNQMP_CSU_STATUS_ENCRYPTED ? "" : "not ");
+}
+
 static bool is_boot_authenticated(void)
 {
 	u32 status = 0;
@@ -541,7 +553,8 @@ int board_init(void)
 	fpga_init();
 	fpga_add(fpga_xilinx, &zynqmppl);
 #endif
-
+	/* display secure boot information */
+	print_secure_boot();
 	if (current_el() == 3) {
 		multiboot = multi_boot_get();
 


### PR DESCRIPTION
Output the secure boot configuration to the console.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
Link: https://lore.kernel.org/r/20211013170447.10414-1-jorge@foundries.io
Signed-off-by: Michal Simek <michal.simek@xilinx.com>


