### PR TITLE
2022.04+lf 5.15.52 2.1.0-fio initial support of 7ulp-evk

### DIFF
--- a/arch/arm/dts/imx7ulp-evk-u-boot.dtsi
+++ b/arch/arm/dts/imx7ulp-evk-u-boot.dtsi
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0+ OR X11
+/*
+ * Copyright 2022 Foundries.io
+ */
+
+&iomuxc1 {
+	u-boot,dm-spl;
+};
+
+&ahbbridge0 {
+	u-boot,dm-spl;
+};
+
+&ahbbridge1 {
+	u-boot,dm-spl;
+};
+
+&lpuart4 {
+	u-boot,dm-spl;
+};
+
+&usbotg1 {
+	extcon = <&usbphy1>;
+	u-boot,dm-spl;
+};
+
+&usbphy1 {
+	u-boot,dm-spl;
+};
+
+&usdhc0 {
+	u-boot,dm-spl;
+};
+
+&gpio0 {
+	u-boot,dm-spl;
+};

--- a/arch/arm/dts/imx7ulp-evk.dts
+++ b/arch/arm/dts/imx7ulp-evk.dts
@@ -9,6 +9,7 @@
 /dts-v1/;
 
 #include "imx7ulp.dtsi"
+#include "imx7ulp-evk-u-boot.dtsi"
 
 / {
 	model = "NXP i.MX7ULP EVK";

--- a/arch/arm/mach-imx/mx7ulp/Kconfig
+++ b/arch/arm/mach-imx/mx7ulp/Kconfig
@@ -59,6 +59,18 @@ config TARGET_MX7ULP_EVK
 	imply FSL_CAAM
 	imply FSL_BLOB
 	select ARCH_MISC_INIT
+	select SPL_DM if SPL
+	select SPL_GPIO if SPL
+	select SPL_LIBCOMMON_SUPPORT if SPL
+	select SPL_LIBDISK_SUPPORT if SPL
+	select SPL_LIBGENERIC_SUPPORT if SPL
+	select SPL_MMC if SPL
+	select SPL_OF_CONTROL if SPL
+	select SPL_OF_LIBFDT if SPL
+	select SPL_PINCTRL if SPL
+	select SPL_SEPARATE_BSS if SPL
+	select SPL_SERIAL if SPL
+	select SUPPORT_SPL
 
 endchoice
 

--- a/board/freescale/mx7ulp_evk/mx7ulp_evk.c
+++ b/board/freescale/mx7ulp_evk/mx7ulp_evk.c
@@ -108,6 +108,32 @@ int board_init(void)
 	return 0;
 }
 
+#ifdef CONFIG_SPL_BUILD
+#include <spl.h>
+
+#ifdef CONFIG_SPL_LOAD_FIT
+int board_fit_config_name_match(const char *name)
+{
+	if (!strcmp(name, "imx7ulp-evk"))
+		return 0;
+
+	return -1;
+}
+#endif
+
+void spl_board_init(void)
+{
+	preloader_console_init();
+}
+
+void board_init_f(ulong dummy)
+{
+	arch_cpu_init();
+
+	board_early_init_f();
+}
+#endif
+
 #if IS_ENABLED(CONFIG_OF_BOARD_SETUP)
 int ft_board_setup(void *blob, struct bd_info *bd)
 {

--- a/board/freescale/mx7ulp_evk/mx7ulp_evk.c
+++ b/board/freescale/mx7ulp_evk/mx7ulp_evk.c
@@ -30,6 +30,7 @@ DECLARE_GLOBAL_DATA_PTR;
 #define UART_PAD_CTRL	(PAD_CTL_PUS_UP)
 #define QSPI_PAD_CTRL1	(PAD_CTL_PUS_UP | PAD_CTL_DSE)
 #define OTG_ID_GPIO_PAD_CTRL	(PAD_CTL_IBE_ENABLE)
+#define OTG_PWR_GPIO_PAD_CTRL   (PAD_CTL_OBE_ENABLE)
 
 int dram_init(void)
 {
@@ -89,6 +90,59 @@ int board_qspi_init(void)
 }
 #endif
 
+#ifdef CONFIG_USB_EHCI_MX6
+static iomux_cfg_t const usb_otg1_pads[] = {
+	/* gpio for otgid */
+	MX7ULP_PAD_PTC13__PTC13 | MUX_PAD_CTRL(OTG_ID_GPIO_PAD_CTRL),
+	/* gpio for power en */
+	MX7ULP_PAD_PTE15__PTE15 | MUX_PAD_CTRL(OTG_PWR_GPIO_PAD_CTRL),
+};
+
+#define OTG0_ID_GPIO	IMX_GPIO_NR(3, 13)
+#define OTG0_PWR_EN	IMX_GPIO_NR(5, 15)
+
+static void setup_usb(void)
+{
+	mx7ulp_iomux_setup_multiple_pads(usb_otg1_pads,
+					 ARRAY_SIZE(usb_otg1_pads));
+	gpio_request(OTG0_ID_GPIO, "otg_id");
+	gpio_direction_input(OTG0_ID_GPIO);
+}
+
+/* Needs to override the ehci power if controlled by GPIO */
+int board_ehci_power(int port, int on)
+{
+	switch (port) {
+	case 0:
+		if (on)
+			gpio_direction_output(OTG0_PWR_EN, 1);
+		else
+			gpio_direction_output(OTG0_PWR_EN, 0);
+		break;
+	default:
+		printf("MXC USB port %d not yet supported\n", port);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int board_usb_phy_mode(int port)
+{
+	/* The device mode is valid for port 0 only */
+	if (port == 0 && gpio_get_value(OTG0_ID_GPIO))
+		return USB_INIT_DEVICE;
+
+	return USB_INIT_HOST;
+}
+#endif
+
+int board_ehci_usb_phy_mode(int port)
+{
+	/* TODO: probe via GPIO to identify if device or host */
+	return USB_INIT_DEVICE;
+}
+
 int board_early_init_f(void)
 {
 	setup_iomux_uart();
@@ -100,6 +154,10 @@ int board_init(void)
 {
 	/* address of boot parameters */
 	gd->bd->bi_boot_params = PHYS_SDRAM + 0x100;
+
+#ifdef CONFIG_USB_EHCI_MX6
+	setup_usb();
+#endif
 
 #ifdef CONFIG_FSL_QSPI
 	board_qspi_init();

--- a/drivers/usb/host/ehci-mx6.c
+++ b/drivers/usb/host/ehci-mx6.c
@@ -633,8 +633,8 @@ err_regulator:
 #if CONFIG_IS_ENABLED(DM_REGULATOR)
 	if (priv->vbus_supply)
 		regulator_set_enable(priv->vbus_supply, false);
-#endif
 err_phy:
+#endif
 #if CONFIG_IS_ENABLED(PHY) && !defined(CONFIG_IMX8)
 	ehci_shutdown_phy(dev, &priv->phy);
 #endif

--- a/include/configs/mx7ulp_evk.h
+++ b/include/configs/mx7ulp_evk.h
@@ -12,6 +12,10 @@
 #include <asm/arch/imx-regs.h>
 #include "imx_env.h"
 
+#ifdef CONFIG_SPL
+#include "imx7ulp_spl.h"
+#endif
+
 #define CONFIG_BOARD_POSTCLK_INIT
 #define CONFIG_SYS_BOOTM_LEN		0x1000000
 
@@ -132,6 +136,8 @@
 	(CONFIG_SYS_INIT_RAM_SIZE - GENERATED_GBL_DATA_SIZE)
 #define CONFIG_SYS_INIT_SP_ADDR \
 	(CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
+
+#define CONFIG_ARMV7_SECURE_BASE	0x2F000000
 
 /* USB Configs */
 #define CONFIG_MXC_USB_PORTSC  (PORT_PTS_UTMI | PORT_PTS_PTW)


### PR DESCRIPTION
Incomplete, but it allows us to build imx7ulp-evk target.