### PR TITLE
[Forwadrport to 2022.04+lf-5.15.71-2.2.0-fio] bootcmd_mfg: start USB again

### DIFF
--- a/include/configs/imx_env.h
+++ b/include/configs/imx_env.h
@@ -57,7 +57,7 @@
 		"rdinit=/linuxrc " \
 		"clk_ignore_unused "\
 		"\0" \
-	"bootcmd_mfg=run mfgtool_args;" \
+	"bootcmd_mfg=usb start; run mfgtool_args;" \
 	FASTBOOT_CMD \
 	"\0" \
 	MFG_NAND_FIT_PARTITION \


### PR DESCRIPTION
Sometimes USB stack becomes stopped in u-boot, which causes it to fail to start fastboot and flash a board:
```
Run fastboot ...
USB init failed: -62
```

As a workaround, start usb again right before running fastboot.

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>