### PR TITLE
Revert "[FIO fromtree] imx8m: drivers/ddr: Change padding of DDR4 and…

### DIFF
--- a/drivers/ddr/imx/phy/helper.c
+++ b/drivers/ddr/imx/phy/helper.c
@@ -17,8 +17,8 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 #define IMEM_LEN 32768 /* byte */
-#define DMEM_LEN 4096  /* byte */
-#define IMEM_2D_OFFSET	36864
+#define DMEM_LEN 16384 /* byte */
+#define IMEM_2D_OFFSET	49152
 
 #define IMEM_OFFSET_ADDR 0x00050000
 #define DMEM_OFFSET_ADDR 0x00054000


### PR DESCRIPTION
… LPDDR4 DMEM firmware"

This reverts commit 8a53b68db3f2e4e95a72734c79022e2377e7b3fc.

Reverting because this change in padding prevents imx93/i.MX 93 EVK board to boot by not loading all the needed firmwares.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
