### PR TITLE
[FIO internal] common: introduce bootfirmware info

### DIFF
--- a/common/Kconfig
+++ b/common/Kconfig
@@ -483,6 +483,13 @@ config DISPLAY_BOARDINFO
 	  when U-Boot starts up. The board function checkboard() is called
 	  to do this.
 
+config BOOTFIRMWARE_INFO
+	bool "Display information about the boot firmware"
+	depends on OF_CONTROL
+	default n
+	help
+	  Display information about the boot firmware (version etc).
+
 config DISPLAY_BOARDINFO_LATE
 	bool "Display information about the board during late start up"
 	help

--- a/common/Makefile
+++ b/common/Makefile
@@ -16,6 +16,7 @@ obj-y += board_f.o
 obj-y += board_r.o
 obj-$(CONFIG_DISPLAY_BOARDINFO) += board_info.o
 obj-$(CONFIG_DISPLAY_BOARDINFO_LATE) += board_info.o
+obj-$(CONFIG_BOOTFIRMWARE_INFO) += bootfirmware_info.o
 
 obj-$(CONFIG_FDT_SIMPLEFB) += fdt_simplefb.o
 obj-$(CONFIG_$(SPL_TPL_)OF_LIBFDT) += fdt_support.o

--- a/common/board_r.c
+++ b/common/board_r.c
@@ -729,6 +729,9 @@ static init_fnc_t init_sequence_r[] = {
 	console_announce_r,
 	show_board_info,
 #endif
+#ifdef CONFIG_BOOTFIRMWARE_INFO
+	get_boot_firmware_info,
+#endif
 #ifdef CONFIG_ARCH_MISC_INIT
 	arch_misc_init,		/* miscellaneous arch-dependent init */
 #endif

--- a/common/bootfirmware_info.c
+++ b/common/bootfirmware_info.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+#include <common.h>
+#include <dm.h>
+#include <init.h>
+#include <sysinfo.h>
+#include <asm/global_data.h>
+#include <linux/libfdt.h>
+#include <linux/compiler.h>
+
+#define COMPATIBLE "lmp,bootloader"
+
+int __weak get_boot_firmware_info(void)
+{
+	char *version;
+	int node;
+
+	node = fdt_node_offset_by_compatible(gd->fdt_blob, -1, COMPATIBLE);
+	if (node < 0) {
+		printf("Can't find node with compatible = \"" COMPATIBLE
+		       "\"\n");
+		return -FDT_ERR_NOTFOUND;
+	}
+
+	version = fdt_getprop(gd->fdt_blob, node, "bootfirmware-version", NULL);
+	if (version) {
+		printf("Boot firmware version: %s\n", version);
+		env_set("dt_bootfirmware_version", version);
+	} else {
+		return -FDT_ERR_NOTFOUND;
+	}
+
+	return 0;
+}

--- a/include/init.h
+++ b/include/init.h
@@ -281,6 +281,9 @@ int init_func_vid(void);
 int checkboard(void);
 int show_board_info(void);
 
+/* common/bootfirmware_info.c */
+int get_boot_firmware_info(void);
+
 /**
  * Get the uppermost pointer that is valid to access
  *


### PR DESCRIPTION
```
Introduce bootfirmware info functionality. Currently it's possible to obtain version from DT and print it during boot:

U-Boot 2022.04+fio+gfd9b3d3ed4 (Mar 15 2023 - 20:28:36 +0000) ....
In:    serial
Out:   serial
Err:   serial
Boot firmware version: 147

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```