### PR TITLE
[FIO internal] common: introduce BOOTFIRMWARE_INFO_STRICT

### DIFF
--- a/common/Kconfig
+++ b/common/Kconfig
@@ -490,6 +490,14 @@ config BOOTFIRMWARE_INFO
 	help
 	  Display information about the boot firmware (version etc).
 
+config BOOTFIRMWARE_INFO_STRICT
+	bool "Enforce boot firmware display"
+	depends on BOOTFIRMWARE_INFO
+	default n
+	help
+	  If the info can not be accessed (e.g. no correct node in DTB),
+	  boot is aborted.
+
 config DISPLAY_BOARDINFO_LATE
 	bool "Display information about the board during late start up"
 	help

--- a/common/bootfirmware_info.c
+++ b/common/bootfirmware_info.c
@@ -14,12 +14,14 @@ int __weak get_boot_firmware_info(void)
 {
 	char *version;
 	int node;
+	int ret = 0;
 
 	node = fdt_node_offset_by_compatible(gd->fdt_blob, -1, COMPATIBLE);
 	if (node < 0) {
 		printf("Can't find node with compatible = \"" COMPATIBLE
 		       "\"\n");
-		return -FDT_ERR_NOTFOUND;
+		ret = -FDT_ERR_NOTFOUND;
+		goto out;
 	}
 
 	version = fdt_getprop(gd->fdt_blob, node, "bootfirmware-version", NULL);
@@ -27,7 +29,15 @@ int __weak get_boot_firmware_info(void)
 		printf("Boot firmware version: %s\n", version);
 		env_set("dt_bootfirmware_version", version);
 	} else {
-		return -FDT_ERR_NOTFOUND;
+		ret = -FDT_ERR_NOTFOUND;
+	}
+
+out:
+	/* we should stop booting, if boot firmware version is not found */
+	if (CONFIG_IS_ENABLED(BOOTFIRMWARE_INFO_STRICT) && ret != 0) {
+		printf("Fail to read boot firmware info from DTB, "
+		       "abort boot as BOOTFIRMWARE_INFO_STRICT is set\n");
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
Introduce BOOTFIRMWARE_INFO_STRICT Kconfig symbol, which can control behavior of U-Boot if error occurs during firmware version detection.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
