### PR TITLE
[FIO fromlist] ARM: imx9: support env in fat and ext4

### DIFF
--- a/arch/arm/mach-imx/imx9/soc.c
+++ b/arch/arm/mach-imx/imx9/soc.c
@@ -997,35 +997,31 @@ int timer_init(void)
 enum env_location env_get_location(enum env_operation op, int prio)
 {
 	enum boot_device dev = get_boot_device();
-	enum env_location env_loc = ENVL_UNKNOWN;
 
 	if (prio)
-		return env_loc;
+		return ENVL_UNKNOWN;
 
 	switch (dev) {
-#ifdef CONFIG_ENV_IS_IN_SPI_FLASH
 	case QSPI_BOOT:
-		env_loc = ENVL_SPI_FLASH;
-		break;
-#endif
-#ifdef CONFIG_ENV_IS_IN_MMC
+		if (CONFIG_IS_ENABLED(ENV_IS_IN_SPI_FLASH))
+			return ENVL_SPI_FLASH;
+		return ENVL_NOWHERE;
 	case SD1_BOOT:
 	case SD2_BOOT:
 	case SD3_BOOT:
 	case MMC1_BOOT:
 	case MMC2_BOOT:
 	case MMC3_BOOT:
-		env_loc =  ENVL_MMC;
-		break;
-#endif
+		if (CONFIG_IS_ENABLED(ENV_IS_IN_MMC))
+			return ENVL_MMC;
+		else if (CONFIG_IS_ENABLED(ENV_IS_IN_EXT4))
+			return ENVL_EXT4;
+		else if (CONFIG_IS_ENABLED(ENV_IS_IN_FAT))
+			return ENVL_FAT;
+		return ENVL_NOWHERE;
 	default:
-#if defined(CONFIG_ENV_IS_NOWHERE)
-		env_loc = ENVL_NOWHERE;
-#endif
-		break;
+		return ENVL_NOWHERE;
 	}
-
-	return env_loc;
 }
 
 int mix_power_init(enum mix_power_domain pd)


### PR DESCRIPTION
Tested building with imx93_11x11_evk_defconfig (+ enabled SPL_MISC + ENV_IS_IN_FAT)

Change boot device logic to also allow environment stored in fat and
in ext4 when booting from SD or eMMC.

As the boot device check for SD and for eMMC was depending on
ENV_IS_IN_MMC being defined, change the ifdef blocks at
env_get_location to use IS_ENABLED instead for all modes, returning
NOWHERE when no valid mode is found.

This solution is based on [1] (with added SPL support).

Upstream-status: Submitted [2]

[1]
Link: https://lore.kernel.org/all/20211020191626.3648540-1-ricardo@foundries.io/
[2]
Link: https://patchwork.ozlabs.org/project/uboot/patch/20230411172741.91910-1-oleksandr.suvorov@foundries.io/
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>