### PR TITLE
Revert "[FIO toup] usb: gadget: ci_udc: introduce board_ci_udc_phy_mode"

### DIFF
--- a/drivers/usb/gadget/ci_udc.c
+++ b/drivers/usb/gadget/ci_udc.c
@@ -1357,14 +1357,17 @@ static int ci_udc_otg_clk_init(struct udevice *dev,
 	return 0;
 }
 
-int __weak board_ci_udc_phy_mode(void *__iomem phy_base, int phy_off)
+static int ci_udc_otg_phy_mode(struct udevice *dev)
 {
+	struct ci_udc_priv_data *priv = dev_get_priv(dev);
+
 	void *__iomem phy_ctrl, *__iomem phy_status;
+	void *__iomem phy_base = (void *__iomem)devfdt_get_addr(&priv->otgdev);
 	u32 val;
 
 	if (is_mx6() || is_mx7ulp() || is_imx8() || is_imx8ulp()) {
 		phy_base = (void __iomem *)fdtdec_get_addr_size_auto_noparent(gd->fdt_blob,
-							   phy_off,
+							   priv->phy_off,
 							   "reg", 0, NULL, false);
 		if ((fdt_addr_t)phy_base == FDT_ADDR_T_NONE)
 			return -EINVAL;
@@ -1386,15 +1389,6 @@ int __weak board_ci_udc_phy_mode(void *__iomem phy_base, int phy_off)
 	} else {
 		return -EINVAL;
 	}
-}
-
-
-static int ci_udc_otg_phy_mode(struct udevice *dev)
-{
-	struct ci_udc_priv_data *priv = dev_get_priv(dev);
-
-	void *__iomem phy_base = (void *__iomem)devfdt_get_addr(&priv->otgdev);
-	return board_ci_udc_phy_mode(phy_base, priv->phy_off);
 }
 
 static int ci_udc_otg_ofdata_to_platdata(struct udevice *dev)


### PR DESCRIPTION
This reverts commit 852e3f665bb9665d330e743100e94514b0f9987a.

Not used by any board, so drop to reduce maintenance.