### PR TITLE
Add secondary boot support for iMX8ULP

### DIFF
--- a/arch/arm/include/asm/arch-imx8ulp/sys_proto.h
+++ b/arch/arm/include/asm/arch-imx8ulp/sys_proto.h
@@ -21,4 +21,7 @@ void load_lposc_fuse(void);
 bool m33_image_booted(void);
 bool is_m33_handshake_necessary(void);
 int m33_image_handshake(ulong timeout_ms);
+int boot_mode_getprisec(void);
+int boot_mode_is_closed(void);
+void boot_mode_enable_secondary(bool enable);
 #endif

--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -26,7 +26,7 @@ config GPT_TIMER
 config SECONDARY_BOOT_RUNTIME_DETECTION
 	bool "SD/MMC sector offset runtime detection"
 	default n
-	depends on (IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP) && SPL_MMC
+	depends on (IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP) && SPL_MMC
 	help
 	  Detect correct sector offset in SPL for the next boot image
 	  in runtime.
@@ -34,7 +34,7 @@ config SECONDARY_BOOT_RUNTIME_DETECTION
 config SECONDARY_BOOT_SECTOR_OFFSET
 	hex "SD/MMC sector offset used for ROM secondary boot"
 	default 0x0
-	depends on IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP
+	depends on IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP
 	help
 	  Set the sector offset to non-zero value in SPL used for
 	  secondary boot image. This value should be same as the
@@ -57,7 +57,7 @@ config IMX_BOOTAUX
 config CMD_SECONDARY_BOOT
 	bool "Use SiP service exposed by trusted firmware for redundant boot control"
 	default n
-	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_IMX8
+	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_IMX8 || ARCH_IMX8ULP
 	select AHAB_BOOT if ARCH_IMX8
 	help
 	  Command for triggering SiP service provided by TF-A for setting/clearing

--- a/arch/arm/mach-imx/imx8ulp/soc.c
+++ b/arch/arm/mach-imx/imx8ulp/soc.c
@@ -1049,3 +1049,62 @@ enum env_location env_get_location(enum env_operation op, int prio)
 		return ENVL_NOWHERE;
 	}
 }
+
+void boot_mode_enable_secondary(bool enable)
+{
+	/* SIM0-SEC DGO_GP6 */
+	if (enable)
+		setbits_le32(SIM_SEC_BASE_ADDR + 0x28, (0x1 << 8));
+	else
+		clrbits_le32(SIM_SEC_BASE_ADDR + 0x28, (0x1 << 8));
+
+	/* set update bit */
+	setbits_le32(SIM_SEC_BASE_ADDR + 0x8, 0x1 << 6);
+
+	/* polling the ack */
+	while ((readl(SIM_SEC_BASE_ADDR + 0x8) & (0x1 << 14)) == 0)
+		;
+
+	/* clear the update */
+	clrbits_le32(SIM_SEC_BASE_ADDR + 0x8, (0x1 << 6));
+
+	/* clear the ack by set 1 */
+	setbits_le32(SIM_SEC_BASE_ADDR + 0x8, (0x1 << 14));
+}
+
+int boot_mode_is_closed(void)
+{
+	u32 lc;
+
+	/* LMDA lifecycle */
+	lc = readl(FSB_BASE_ADDR + 0x41c);
+	lc &= 0x3ff;
+
+	/* OEM closed */
+	if (lc == 0x20)
+		return 1;
+
+	/* Ignore all other modes, assume open */
+
+	return 0;
+}
+
+int boot_mode_getprisec(void)
+{
+	volatile gd_t *pgd = gd;
+	u32 bstage = 0;
+	int ret;
+
+	ret = g_rom_api->query_boot_infor(QUERY_BT_STAGE, &bstage,
+					  ((uintptr_t)&bstage) ^ QUERY_BT_STAGE);
+	set_gd(pgd);
+
+	if (ret != ROM_API_OKAY)
+		printf("ROMAPI: failure at query_boot_info for BT_STAGE\n");
+
+	/* Only handle secondary, return 'primary' for everything else */
+	if (bstage == BT_STAGE_SECONDARY)
+		return 1;
+
+	return 0;
+}

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -518,7 +518,7 @@ unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 	return offset;
 }
 
-#if defined(CONFIG_IMX8QM) || defined(CONFIG_IMX8QXP)
+#if defined(CONFIG_IMX8QM) || defined(CONFIG_IMX8QXP) || defined(CONFIG_IMX8ULP)
 int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 {
 	return boot_mode_getprisec() ? 2 : 1;

--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -296,7 +296,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp()) {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = boot_partition;
@@ -327,7 +327,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp()) {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = boot_partition;


### PR DESCRIPTION
imx8ulp is a mix of 8qm/8qxp and 7ulp, with the main difference being the presence of ELE (responsible for the fuses, validation and more).

Secondary boot for imx8ulp:
- uses emmc boot0/1 for primary/secondary boot firmware
- identifies if closed/open via LMDA lifecycle (OEM closed/open)
- supports setting primary/secondary boot flag via SIM0-SEC DGO_GP6 (DGO keeps state on warm reboots)
- primary / secondary boot detection via ROM api