### PR TITLE
[FIO toup] imx8m: ddr: Reduce DDR4/LPDDR4 DMEM firmware padding

### DIFF
--- a/drivers/ddr/imx/phy/helper.c
+++ b/drivers/ddr/imx/phy/helper.c
@@ -17,8 +17,12 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 #define IMEM_LEN 32768 /* byte */
+#if CONFIG_IS_ENABLED(IMX8M)
+#define DMEM_LEN 4096 /* byte */
+#else
 #define DMEM_LEN 16384 /* byte */
-#define IMEM_2D_OFFSET	49152
+#endif
+#define IMEM_2D_OFFSET (IMEM_LEN + DMEM_LEN)
 
 #define IMEM_OFFSET_ADDR 0x00050000
 #define DMEM_OFFSET_ADDR 0x00054000


### PR DESCRIPTION
DMEM firmware files are padded to 16KB, wasting precious space in processor internal RAM (TMU). The actual size of these files is less than 2KB, so padding them to PAGE_SIZE is sufficient.

This patch changes the expected size of DMEM firmware. It needs to change boot image creation tools to generate 4KB padding.