### PR TITLE
imx93: extend support for lmp with spl -> u-boot.itb and secondary boot support

### DIFF
--- a/arch/arm/include/asm/arch-imx9/sys_proto.h
+++ b/arch/arm/include/asm/arch-imx9/sys_proto.h
@@ -17,4 +17,7 @@ int mix_power_init(enum mix_power_domain pd);
 void soc_power_init(void);
 bool m33_is_rom_kicked(void);
 int m33_prepare(void);
+int boot_mode_getprisec(void);
+int boot_mode_is_closed(void);
+void boot_mode_enable_secondary(bool enable);
 #endif

--- a/arch/arm/mach-imx/Kconfig
+++ b/arch/arm/mach-imx/Kconfig
@@ -26,7 +26,7 @@ config GPT_TIMER
 config SECONDARY_BOOT_RUNTIME_DETECTION
 	bool "SD/MMC sector offset runtime detection"
 	default n
-	depends on (IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP) && SPL_MMC
+	depends on (IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP || IMX93) && SPL_MMC
 	help
 	  Detect correct sector offset in SPL for the next boot image
 	  in runtime.
@@ -34,7 +34,7 @@ config SECONDARY_BOOT_RUNTIME_DETECTION
 config SECONDARY_BOOT_SECTOR_OFFSET
 	hex "SD/MMC sector offset used for ROM secondary boot"
 	default 0x0
-	depends on IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP
+	depends on IMX8MQ || IMX8MM || IMX8MP || IMX8MN || MX6ULL || MX6UL || MX6 || MX7 || MX7ULP || IMX8QM || IMX8QXP || IMX8ULP || IMX93
 	help
 	  Set the sector offset to non-zero value in SPL used for
 	  secondary boot image. This value should be same as the
@@ -57,7 +57,7 @@ config IMX_BOOTAUX
 config CMD_SECONDARY_BOOT
 	bool "Use SiP service exposed by trusted firmware for redundant boot control"
 	default n
-	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_IMX8 || ARCH_IMX8ULP
+	depends on ARCH_IMX8M || ARCH_MX6 || ARCH_MX7 || ARCH_MX7ULP || ARCH_IMX8 || ARCH_IMX8ULP || ARCH_IMX9
 	select AHAB_BOOT if ARCH_IMX8
 	help
 	  Command for triggering SiP service provided by TF-A for setting/clearing

--- a/board/freescale/imx93_evk/spl.c
+++ b/board/freescale/imx93_evk/spl.c
@@ -37,7 +37,20 @@ DECLARE_GLOBAL_DATA_PTR;
 
 int spl_board_boot_device(enum boot_device boot_dev_spl)
 {
+#ifdef CONFIG_SPL_BOOTROM_SUPPORT
 	return BOOT_DEVICE_BOOTROM;
+#else
+	switch (boot_dev_spl) {
+	case SD1_BOOT:
+	case MMC1_BOOT:
+		return BOOT_DEVICE_MMC1;
+	case SD2_BOOT:
+	case MMC2_BOOT:
+		return BOOT_DEVICE_MMC2;
+	default:
+		return BOOT_DEVICE_NONE;
+	}
+#endif
 }
 
 void spl_board_init(void)

--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -296,7 +296,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93()) {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = boot_partition;
@@ -327,7 +327,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93()) {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = boot_partition;

--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -1924,7 +1924,11 @@ static const struct mode_width_tuning mmc_modes_by_pref[] = {
 #if CONFIG_IS_ENABLED(MMC_HS200_SUPPORT)
 	{
 		.mode = MMC_HS_200,
+#if defined(CONFIG_SPL_BUILD) && defined(CONFIG_IMX93_EVK_LPDDR4X)
+		.widths = MMC_MODE_4BIT,
+#else
 		.widths = MMC_MODE_8BIT | MMC_MODE_4BIT,
+#endif
 		.tuning = MMC_CMD_SEND_TUNING_BLOCK_HS200
 	},
 #endif


### PR DESCRIPTION
Add support to load u-boot.itb images out of MMC from SPL and the basic requirements for secondary boot support.

Things to note:
- boot_mode_enable_secondary is not yet implemented due lack of documentation, but since this boards boot using the alternative path it shouldn't be an issue
- for some unknown reason mmc init in SPL fails on high speed modes, causing a boot delay, so a hack was added for a faster boot (still needs investigation)