### PR TITLE
[FIO squash] imx8m: ddr: fix changing padding

### DIFF
--- a/drivers/ddr/imx/phy/helper.c
+++ b/drivers/ddr/imx/phy/helper.c
@@ -17,7 +17,7 @@
 DECLARE_GLOBAL_DATA_PTR;
 
 #define IMEM_LEN 32768 /* byte */
-#if CONFIG_IS_ENABLED(IMX8M)
+#if IS_ENABLED(CONFIG_IMX8M)
 #define DMEM_LEN 4096 /* byte */
 #else
 #define DMEM_LEN 16384 /* byte */


### PR DESCRIPTION
We should have changed padding in SPL. Fix checking IMX8M family.

Fixes:   9af5f2d5c60 ("[FIO toup] imx8m: ddr: Reduce DDR4/LPDDR4 DMEM firmware padding")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
