### PR TITLE
fastboot: fsl: imx8qm: extend bootloader2 partition

### DIFF
--- a/include/fb_fsl.h
+++ b/include/fb_fsl.h
@@ -147,10 +147,14 @@
  * the manixum size of bootloader is half of boot partition size
  * excluding MMC bootloader offset
 */
+#ifdef CONFIG_IMX8QM
+#define ANDROID_BOOTLOADER_SIZE    0x400000
+#else
 #define ANDROID_BOOTLOADER_SIZE    0x200000
+#endif /* CONFIG_IMX8QM */
 #else
 #define ANDROID_BOOTLOADER_SIZE    0x400000
-#endif
+#endif /* CONFIG_FSL_FASTBOOT_BOOTLOADER_SECONDARY */
 
 #define ANDROID_GPT_OFFSET         0
 #define ANDROID_GPT_SIZE           0x100000


### PR DESCRIPTION
Extend the size of bootloader2 partition for iMX8QM. This fixes error during uuu script execution:

$ sudo mfgtool-files/uuu -pp 1 mfgtool-files/bootloader.uuu
Success 0    Failure 1
3:742 6/ 9 [image too large for partition] FB: flash bootloader2

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
