### PR TITLE
Allow enabling HAS_CAAM again

### DIFF
--- a/arch/arm/mach-imx/imx8/Kconfig
+++ b/arch/arm/mach-imx/imx8/Kconfig
@@ -20,7 +20,7 @@ config IMX_LOAD_HDMI_FIMRWARE_TX
 
 config IMX8
 	bool
-	select HAS_CAAM if !OPTEE
+	select HAS_CAAM
 
 config MU_BASE_SPL
 	hex "MU base address used in SPL"

--- a/arch/arm/mach-imx/imx8/cpu.c
+++ b/arch/arm/mach-imx/imx8/cpu.c
@@ -105,7 +105,7 @@ int arch_cpu_init_dm(void)
 #if defined(CONFIG_ARCH_MISC_INIT)
 int arch_misc_init(void)
 {
-#if !defined(CONFIG_ANDROID_SUPPORT) && !defined(CONFIG_ANDROID_AUTO_SUPPORT) && !defined(CONFIG_OPTEE)
+#if !defined(CONFIG_ANDROID_SUPPORT) && !defined(CONFIG_ANDROID_AUTO_SUPPORT)
 	if (IS_ENABLED(CONFIG_FSL_CAAM)) {
 		struct udevice *dev;
 		int ret;

--- a/arch/arm/mach-imx/imx8m/Kconfig
+++ b/arch/arm/mach-imx/imx8m/Kconfig
@@ -2,7 +2,7 @@ if ARCH_IMX8M
 
 config IMX8M
 	bool
-	select HAS_CAAM if !OPTEE
+	select HAS_CAAM
 	select ROM_UNIFIED_SECTIONS
 
 config IMX8MQ

--- a/arch/arm/mach-imx/mx7ulp/Kconfig
+++ b/arch/arm/mach-imx/mx7ulp/Kconfig
@@ -12,7 +12,7 @@ config MX7ULP
 	select ARCH_SUPPORT_PSCI if !OPTEE
 	select CPU_V7_HAS_NONSEC if !OPTEE
 	select CPU_V7_HAS_VIRT if !OPTEE
-	select HAS_CAAM if !OPTEE
+	select HAS_CAAM
 	bool
 
 config IMX_M4_BIND


### PR DESCRIPTION
When secure boot was initially enabled we had to disable CAAM because SPL/U-Boot/OP-TEE/Linux were all sharing the same CAAM job ring, causing runtime conflict (due OP-TEE requiring JR exclusive access).

This is not the case anymore with current BSP as secure world is now using a dedicated JR, allowing both u-boot and kernel to have access to CAAM for crypto acceleration support.

While this is needed to get iMX8MN to boot correctly (with CAAM RNG being initialized in SPL and later in OP-TEE), we shouldn't force HAS_CAAM to be removed when OP-TEE is enabled anymore.

The annoying part is that we will have to review all affect boards since CAAM will now be enabled unless not required explicitly via config.