### PR TITLE
[FIO internal] lib: rsa: do not autoselect RSA_FREESCALE_EXP

### DIFF
--- a/lib/rsa/Kconfig
+++ b/lib/rsa/Kconfig
@@ -1,6 +1,5 @@
 config RSA
 	bool "Use RSA Library"
-	select RSA_FREESCALE_EXP if FSL_CAAM && !ARCH_MX7 && !ARCH_MX7ULP && !ARCH_MX6 && !ARCH_MX5
 	select RSA_ASPEED_EXP if ASPEED_ACRY
 	select RSA_SOFTWARE_EXP if !RSA_FREESCALE_EXP && !RSA_ASPEED_EXP
 	help
@@ -49,7 +48,7 @@ config RSA_VERIFY_WITH_PKEY
 
 config RSA_SOFTWARE_EXP
 	bool "Enable driver for RSA Modular Exponentiation in software"
-	depends on DM
+	depends on DM && !RSA_FREESCALE_EXP && !RSA_ASPEED_EXP
 	help
 	  Enables driver for modular exponentiation in software. This is a RSA
 	  algorithm used in FIT image verification. It required RSA Key as


### PR DESCRIPTION
Let the user still be able to use the SW implementation if wanted.

This is needed as the HW implementation fails padding check when using the RSA public key and signature available in FIT, needs investigation.