### PR TITLE
[FIO backport] ARM: dts: imx6-apalis: sync mmc aliases with kernel

### DIFF
--- a/arch/arm/dts/imx6-apalis-u-boot.dtsi
+++ b/arch/arm/dts/imx6-apalis-u-boot.dtsi
@@ -8,7 +8,7 @@
 / {
 
 	aliases {
-		mmc0 = &usdhc3;
+		mmc2 = &usdhc3;
 	};
 
 	reg_module_3v3: regulator-module-3v3 {

--- a/arch/arm/dts/imx6-apalis.dts
+++ b/arch/arm/dts/imx6-apalis.dts
@@ -12,9 +12,10 @@
 	compatible = "toradex,apalis_imx6q", "fsl,imx6q";
 
 	aliases {
-		mmc0 = &usdhc3;
-		mmc1 = &usdhc1;
-		mmc2 = &usdhc2;
+		mmc0 = &usdhc1;
+		mmc1 = &usdhc2;
+		mmc2 = &usdhc3;
+		mmc3 = &usdhc4;
 		usb0 = &usbotg; /* required for ums */
 		ethernet0 = &fec;
 	};


### PR DESCRIPTION
Latest kernel has a different mmc alias order from what is currently available in u-boot, so sync in order for the mmc device to be the same on both u-boot and kernel.

This is not required upstream as dtb kernel sync was done as part of the 2022.07 release.