### PR TITLE
[FIO extras] board: rpi: always set fdt_addr if provided by firmware

### DIFF
--- a/board/raspberrypi/rpi/rpi.c
+++ b/board/raspberrypi/rpi/rpi.c
@@ -323,9 +323,6 @@ static void set_fdtfile(void)
  */
 static void set_fdt_addr(void)
 {
-	if (env_get("fdt_addr"))
-		return;
-
 	if (fdt_magic(fw_dtb_pointer) != FDT_MAGIC)
 		return;
 


### PR DESCRIPTION
Otherwise if the env gets saved with an incorrect or different fdt_addr (by moving sdcard between different rpi versions), it won't be able to boot with the correct address.

This allows fdt_addr to always be in sync with what gets set by the firmware.