### PR TITLE
[RFC] 2022.04+lf 6.1.1 1.0.0-fio: fix boot area size

### DIFF
--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -300,7 +300,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	ptable[PTN_BOOTLOADER2_INDEX].start =
 				(CONFIG_FSL_FASTBOOT_BOOTLOADER2_OFFSET * dev_desc->blksz) / dev_desc->blksz;
 	ptable[PTN_BOOTLOADER2_INDEX].length =
-				(ANDROID_BOOTLOADER_SIZE - (CONFIG_FSL_FASTBOOT_BOOTLOADER2_OFFSET * dev_desc->blksz))
+				(boot_loader_psize - (CONFIG_FSL_FASTBOOT_BOOTLOADER2_OFFSET * dev_desc->blksz))
 				/ dev_desc->blksz;
 	ptable[PTN_BOOTLOADER2_INDEX].partition_id = boot_partition;
 	ptable[PTN_BOOTLOADER2_INDEX].flags = FASTBOOT_PTENTRY_FLAGS_UNERASEABLE;

--- a/include/fb_fsl.h
+++ b/include/fb_fsl.h
@@ -141,20 +141,15 @@
 
 #define ANDROID_MBR_OFFSET	    0
 #define ANDROID_MBR_SIZE	    0x200
-#ifdef CONFIG_FSL_FASTBOOT_BOOTLOADER_SECONDARY
 /*
- * If we support secondary boot and use boot partition
- * the manixum size of bootloader is half of boot partition size
- * excluding MMC bootloader offset
+ * If we support secondary boot and use boot partition, we need to double
+ * boot partition size to have enough space for the second bootloader
+ * images. U-Boot for MFGTool doesn't know about a type of flashing image,
+ * so it shouldn't reduce space for each bootloader images set
+ * (primary/secondary) in order to avoid flashing errors like:
+ * ... 6/ 9 [image too large for partition] FB: flash bootloader2 u-boot.itb
 */
-#ifdef CONFIG_IMX8QM
 #define ANDROID_BOOTLOADER_SIZE    0x400000
-#else
-#define ANDROID_BOOTLOADER_SIZE    0x200000
-#endif /* CONFIG_IMX8QM */
-#else
-#define ANDROID_BOOTLOADER_SIZE    0x400000
-#endif /* CONFIG_FSL_FASTBOOT_BOOTLOADER_SECONDARY */
 
 #define ANDROID_GPT_OFFSET         0
 #define ANDROID_GPT_SIZE           0x100000


### PR DESCRIPTION
Extend the size of bootloader2 partition for all i.MX-based boards.
