### PR TITLE
[FIO fromlist] lib/zlib: Fix a bug when getting a gzip header extra f…

### DIFF
--- a/lib/zlib/inflate.c
+++ b/lib/zlib/inflate.c
@@ -455,8 +455,9 @@ int ZEXPORT inflate(z_streamp strm, int flush)
                 if (copy > have) copy = have;
                 if (copy) {
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        (len = state->head->extra_len - state->length) <
+                            state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
…ield

This fixes CVE-2022-37434 [1] and bases on 2 commits from Mark Adler's zlib master repo - the original fix of CVE bug [2] and the fix for the fix [3].

[1]
https://github.com/advisories/GHSA-cfmr-vrgj-vqwv
[2]
https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1 [3]
https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d

Fixes: e89516f031d ("zlib: split up to match original source tree")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
