### PR TITLE
[FIO internal] ARM: dts: stm32mp157c-ev1: recover optee node

### DIFF
--- a/arch/arm/dts/stm32mp157c-ev1-u-boot.dtsi
+++ b/arch/arm/dts/stm32mp157c-ev1-u-boot.dtsi
@@ -4,3 +4,16 @@
  */
 
 #include "stm32mp157a-ev1-u-boot.dtsi"
+
+#ifdef CONFIG_OPTEE
+/ {
+	firmware {
+		optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+			rpmb-dev = <&sdmmc2>;
+			u-boot,dm-pre-reloc;
+		};
+	};
+};
+#endif


### PR DESCRIPTION
Recover optee node with RPMB dev provided. TEE device is needed by both fiovb and ST BSEC OTP driver.

Fixes: fd9b3d3ed ("[FIO fromstm] dts: stm32mp1: alignment with v5.15-stm32mp-r1")

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
