### PR TITLE
[FIO toup] zynqmp: use primary offset by default

### DIFF
--- a/board/xilinx/zynqmp/zynqmp.c
+++ b/board/xilinx/zynqmp/zynqmp.c
@@ -1080,14 +1080,10 @@ unsigned int spl_spi_get_uboot_offs(struct spi_flash *flash)
 	 * Secondary boot.bin offset - 0x50000 (multiboot == 10,
 	 *                             as 10 * 32KB == 0x50000)
 	 */
-	if (boot_image_offset == CONFIG_SYS_SPI_BOOT_IMAGE_OFFS) {
-		payload_offset = CONFIG_SYS_SPI_U_BOOT_OFFS;
-	} else if (boot_image_offset == CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2) {
+	if (boot_image_offset == CONFIG_SYS_SPI_BOOT_IMAGE_OFFS2) {
 		payload_offset = CONFIG_SYS_SPI_U_BOOT_OFFS2;
 	} else {
-		printf("Invalid value of multiboot register, value = %d\n",
-		       multiboot);
-		hang();
+		payload_offset = CONFIG_SYS_SPI_U_BOOT_OFFS;
 	}
 
 	printf("SPL: Booting next image from 0x%x SPI offset\n",


### PR DESCRIPTION
Restart Golden Image Search instead of hang if boot.bin was booted from unsupported multiboot offset.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
