### PR TITLE
[FIO internal] common: support bootfirmware info in spl

### DIFF
--- a/common/Kconfig
+++ b/common/Kconfig
@@ -490,9 +490,24 @@ config BOOTFIRMWARE_INFO
 	help
 	  Display information about the boot firmware (version etc).
 
+config SPL_BOOTFIRMWARE_INFO
+	bool "Display information about the boot firmware in SPL"
+	depends on SPL_OF_CONTROL
+	default n
+	help
+	  Display information about the boot firmware (version etc) in SPL.
+
 config BOOTFIRMWARE_INFO_STRICT
 	bool "Enforce boot firmware display"
 	depends on BOOTFIRMWARE_INFO
+	default n
+	help
+	  If the info can not be accessed (e.g. no correct node in DTB),
+	  boot is aborted.
+
+config SPL_BOOTFIRMWARE_INFO_STRICT
+	bool "Enforce boot firmware display in SPL"
+	depends on SPL_BOOTFIRMWARE_INFO
 	default n
 	help
 	  If the info can not be accessed (e.g. no correct node in DTB),

--- a/common/Makefile
+++ b/common/Makefile
@@ -16,7 +16,6 @@ obj-y += board_f.o
 obj-y += board_r.o
 obj-$(CONFIG_DISPLAY_BOARDINFO) += board_info.o
 obj-$(CONFIG_DISPLAY_BOARDINFO_LATE) += board_info.o
-obj-$(CONFIG_BOOTFIRMWARE_INFO) += bootfirmware_info.o
 
 obj-$(CONFIG_FDT_SIMPLEFB) += fdt_simplefb.o
 obj-$(CONFIG_$(SPL_TPL_)OF_LIBFDT) += fdt_support.o
@@ -48,6 +47,7 @@ obj-$(CONFIG_CMDLINE) += cli_readline.o cli_simple.o
 
 endif # !CONFIG_SPL_BUILD
 
+obj-$(CONFIG_$(SPL_TPL_)BOOTFIRMWARE_INFO) += bootfirmware_info.o
 obj-$(CONFIG_$(SPL_TPL_)BOOTSTAGE) += bootstage.o
 obj-$(CONFIG_$(SPL_TPL_)BLOBLIST) += bloblist.o
 

--- a/common/bootfirmware_info.c
+++ b/common/bootfirmware_info.c
@@ -27,7 +27,9 @@ int __weak get_boot_firmware_info(void)
 	version = fdt_getprop(gd->fdt_blob, node, "bootfirmware-version", NULL);
 	if (version) {
 		printf("Boot firmware version: %s\n", version);
+#if CONFIG_IS_ENABLED(ENV_SUPPORT)
 		env_set("dt_bootfirmware_version", version);
+#endif
 	} else {
 		ret = -FDT_ERR_NOTFOUND;
 	}

--- a/common/spl/spl.c
+++ b/common/spl/spl.c
@@ -756,6 +756,15 @@ void board_init_r(gd_t *dummy1, ulong dummy2)
 #endif
 #endif
 
+#ifdef CONFIG_SPL_BOOTFIRMWARE_INFO
+	ret = get_boot_firmware_info();
+	if (ret) {
+		printf(SPL_TPL_PROMPT
+		       "SPL firmware version detect failed (err=%d)\n", ret);
+		hang();
+	}
+#endif
+
 	if (IS_ENABLED(CONFIG_SPL_OS_BOOT) || CONFIG_IS_ENABLED(HANDOFF) ||
 	    IS_ENABLED(CONFIG_SPL_ATF) || IS_ENABLED(CONFIG_SPL_OPTEE))
 		dram_init_banksize();


### PR DESCRIPTION
Support showing boot firmware info (like version etc.) in SPL. All these details are obtained from SPL DTB.

Example:
```
U-Boot SPL 2022.04+fio+gd7db7d85cda (Sep 26 2023 - 13:20:54 +0000) 
Boot firmware version: 73
```

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
