### PR TITLE
[FIO toup] fastboot: fb_fsl: add support for imx8mp and imx8mn

### DIFF
--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -296,7 +296,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93() || is_imx8mp() || is_imx8mn()) {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER_SECONDARY_INDEX].partition_id = boot_partition;
@@ -327,7 +327,7 @@ static int _fastboot_parts_load_from_ptable(void)
 	 * which means that secondary boot image set should be flashed to boot1 partition to the
 	 * same offset the primary one
 	 */
-	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93()) {
+	if (is_imx8qm() || is_imx8qxp() || is_imx8ulp() || is_imx93() || is_imx8mp() || is_imx8mn()) {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = FASTBOOT_MMC_BOOT1_PARTITION_ID;
 	} else {
 		ptable[PTN_BOOTLOADER2_SECONDARY_INDEX].partition_id = boot_partition;


### PR DESCRIPTION
Use boot1 partition for secondary boot image set.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
