### PR TITLE
fix booting for imx8mn-*

### DIFF
--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -554,11 +554,6 @@ unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 {
 	int boot_secondary = boot_mode_getprisec();
 	unsigned long offset = CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR;
-#if defined(CONFIG_IMX8MN)
-	#define UBOOT_MMC2_RAW_SECTOR_OFFSET 0x40
-	if (spl_boot_device() == BOOT_DEVICE_MMC2)
-			offset -= UBOOT_MMC2_RAW_SECTOR_OFFSET;
-#endif
 	if (boot_secondary) {
 		offset += CONFIG_SECONDARY_BOOT_SECTOR_OFFSET;
 		printf("SPL: Booting secondary boot path: using 0x%lx offset "

--- a/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
+++ b/drivers/fastboot/fb_fsl/fb_fsl_partitions.c
@@ -151,6 +151,11 @@ static int _fastboot_parts_add_ptable_entry(int ptable_index,
 		strcpy(ptable[ptable_index].fstype, "f2fs");
 	else
 		strcpy(ptable[ptable_index].fstype, "raw");
+
+	debug("Add ptable entry [%d]: 0x%lx, 0x%lx, %d, %d, %s, %s\n",
+	      ptable_index, info.start, info.size,
+	      mmc_partition_index, mmc_dos_partition_index,
+	      ptable[ptable_index].name, ptable[ptable_index].fstype);
 	return 0;
 }
 


### PR DESCRIPTION
[FIO internal] imx8mn: spl: remove adjusting start sector for MMC2
      
The NXP commit [1] and its LmP version [2] break booting LmP. Remove the
adjustment of start sector for MMC2 to fix LmP booting.
      
[1]
commit c72a447592b ("MA-15087-4 Support mmc loader for imx8mn_evk")
      
[2]
commit  ccd549f5a8f ("[FIO internal] ARM: mach-imx: spl: add support of imx8mn_evk in spl_mmc_get_uboot_raw_sector()")
      
Fixes: ccd549f5a8f ("[FIO internal] ARM: mach-imx: spl: add support of imx8mn_evk in spl_mmc_get_uboot_raw_sector()")
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
