### PR TITLE
[FIO toup] imx8mp-evk: fix building for various configs

### DIFF
--- a/include/configs/imx8mp_evk.h
+++ b/include/configs/imx8mp_evk.h
@@ -22,10 +22,24 @@
 #endif
 
 #ifdef CONFIG_DISTRO_DEFAULTS
-#define BOOT_TARGET_DEVICES(func) \
-	func(USB, usb, 0) \
+
+#if CONFIG_IS_ENABLED(CMD_MMC)
+#define BOOT_TARGET_MMC(func) \
 	func(MMC, mmc, 1) \
 	func(MMC, mmc, 2)
+#else
+#define BOOT_TARGET_MMC(func)
+#endif
+
+#if CONFIG_IS_ENABLED(CMD_USB)
+#define BOOT_TARGET_USB(func) func(USB, usb, 0)
+#else
+#define BOOT_TARGET_USB(func)
+#endif
+
+#define BOOT_TARGET_DEVICES(func) \
+	BOOT_TARGET_MMC(func) \
+	BOOT_TARGET_USB(func)
 
 #include <config_distro_bootcmd.h>
 #else


### PR DESCRIPTION
If there are no CMD_USB/CMD_MMC set, u-boot fails to build [1]. Fix the issue populating targets for enabled options only.

[1]
include/config_distro_bootcmd.h:302:9: error: expected ‘}’ before ‘BOOT_TARGET_DEVICES_references_USB_without_CONFIG_CMD_USB’
  302 |         BOOT_TARGET_DEVICES_references_USB_without_CONFIG_CMD_USB
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/config_distro_bootcmd.h:452:9: note: in expansion of macro ‘BOOTENV_DEV_NAME_USB’
  452 |         BOOTENV_DEV_NAME_##devtypeu(devtypeu, devtypel, instance, ## __VA_ARGS__)
      |         ^~~~~~~~~~~~~~~~~
include/configs/imx8mp_evk.h:26:9: note: in expansion of macro ‘BOOTENV_DEV_NAME’
   26 |         func(USB, usb, 0) \
      |         ^~~~
include/config_distro_bootcmd.h:454:25: note: in expansion of macro ‘BOOT_TARGET_DEVICES’
  454 |         "boot_targets=" BOOT_TARGET_DEVICES(BOOTENV_DEV_NAME) "\0"
      |                         ^~~~~~~~~~~~~~~~~~~
include/config_distro_bootcmd.h:474:9: note: in expansion of macro ‘BOOTENV_BOOT_TARGETS’
  474 |         BOOTENV_BOOT_TARGETS \
      |         ^~~~~~~~~~~~~~~~~~~~
include/configs/imx8mp_evk.h:90:9: note: in expansion of macro ‘BOOTENV’
   90 |         BOOTENV \
      |         ^~~~~~~
include/env_default.h:122:9: note: in expansion of macro ‘CFG_EXTRA_ENV_SETTINGS’
  122 |         CFG_EXTRA_ENV_SETTINGS
      |         ^~~~~~~~~~~~~~~~~~~~~~
In file included from env/common.c:32:
include/env_default.h:29:36: note: to match this ‘{’
   29 | const char default_environment[] = {
      |                                    ^
Upstream-Status: Pending
Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>
