### PR TITLE
[FIO fromtree] ARM: imx: Fix parsing of ROM log event IDs on iMX8M

### DIFF
--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -710,6 +710,7 @@ int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 		/* Log entries with 1 parameter, skip 1 */
 		case 0x80: /* Start to perform the device initialization */
 		case 0x81: /* The boot device initialization completes */
+		case 0x82: /* Starts to execute boot device driver pre-config */
 		case 0x8f: /* The boot device initialization fails */
 		case 0x90: /* Start to read data from boot device */
 		case 0x91: /* Reading data from boot device completes */

--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -683,8 +683,7 @@ enum boot_device get_boot_device(void)
 }
 #endif
 
-#if !defined(CONFIG_SECONDARY_BOOT_RUNTIME_DETECTION) && \
-    defined(CONFIG_IMX8M)
+#if defined(CONFIG_IMX8MP) && defined(CONFIG_IMX8MN)
 #include <spl.h>
 int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 {
@@ -743,6 +742,17 @@ int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 	}
 
 	return part;
+}
+unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
+					   unsigned long raw_sect)
+{
+	unsigned long offset = CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR;
+#if defined(CONFIG_iMX8MN)
+	#define UBOOT_MMC2_RAW_SECTOR_OFFSET 0x40
+	if (spl_boot_device() == BOOT_DEVICE_MMC2)
+			offset -= UBOOT_MMC2_RAW_SECTOR_OFFSET;
+#endif
+	return offset;
 }
 #endif
 

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -560,11 +560,7 @@ unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 {
 	int boot_secondary = boot_mode_getprisec();
 	unsigned long offset = CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR;
-#if defined(CONFIG_iMX8MN)
-	#define UBOOT_MMC2_RAW_SECTOR_OFFSET 0x40
-	if (spl_boot_device() == BOOT_DEVICE_MMC2)
-			offset -= UBOOT_MMC2_RAW_SECTOR_OFFSET;
-#endif
+
 	if (boot_secondary) {
 		offset += CONFIG_SECONDARY_BOOT_SECTOR_OFFSET;
 		printf("SPL: Booting secondary boot path: using 0x%lx offset "


### PR DESCRIPTION
It seems like the ROM log events for the iMX8M are not fully covered by AN12853 i.MX ROMs Log Events, Rev. 0, May 2020. On iMX8M the ROM event ID 0x82 seems to use parameter0 which stops the parsing because the end of list is detected too early.

This patch adds ROM event ID 0x82 and skips the next word if ID 0x82 is parsed.

Fixes: a5ee05cf71 ("ARM: imx: Pick correct eMMC boot partition from ROM log")

Signed-off-by: Fedor Ross <fedor.ross@ifm.com>
Cc: Fabio Estevam <festevam@gmail.com>
Cc: Marek Vasut <marex@denx.de>
Cc: Peng Fan <peng.fan@nxp.com>
Cc: Stefano Babic <sbabic@denx.de>
Reviewed-by: Peng Fan <peng.fan@nxp.com>
(cherry picked from commit b1d20ae5a648e50fa7fa20981b4ebc6c5c206fa8)

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
