### PR TITLE
board: imx8mp_evk: fix building with DM_USB_GADGET

### DIFF
--- a/board/freescale/imx8mp_evk/imx8mp_evk.c
+++ b/board/freescale/imx8mp_evk/imx8mp_evk.c
@@ -305,11 +305,13 @@ static struct dwc3_device dwc3_device_data = {
 	.power_down_scale = 2,
 };
 
+#if !CONFIG_IS_ENABLED(DM_USB_GADGET)
 int usb_gadget_handle_interrupts(int index)
 {
 	dwc3_uboot_handle_interrupt(index);
 	return 0;
 }
+#endif
 
 static void dwc3_nxp_usb_phy_init(struct dwc3_device *dwc3)
 {


### PR DESCRIPTION
DM-based USB gadget driver declares its own function usb_gadget_handle_interrupts().

Declare non-DM version of this function conditionally to fix linking error [1].

[1]
| ld: drivers/usb/gadget/udc/udc-uclass.o (symbol from plugin): in function `usb_gadget_initialize': | (.text+0x0): multiple definition of `usb_gadget_handle_interrupts'; board/freescale/imx8mp_evk/imx8mp_evk.o (symbol from plugin):(.text+0x0): first defined here | collect2: error: ld returned 1 exit status