### PR TITLE
2023.04+lf 6.1.36 2.1.0-fio: fix disabling spl_imx_hab

### DIFF
--- a/arch/arm/include/asm/mach-imx/hab.h
+++ b/arch/arm/include/asm/mach-imx/hab.h
@@ -137,7 +137,7 @@ struct imx_sec_config_fuse_t {
 	int word;
 };
 
-#if defined(CONFIG_IMX_HAB)
+#if CONFIG_IS_ENABLED(IMX_HAB)
 extern struct imx_sec_config_fuse_t const imx_sec_config_fuse;
 #endif
 
@@ -235,5 +235,4 @@ typedef void hapi_clock_init_t(void);
 int imx_hab_authenticate_image(uint32_t ddr_start, uint32_t image_size,
 			       uint32_t ivt_offset);
 bool imx_hab_is_enabled(void);
-
 #endif

--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -41,7 +41,7 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
-#if defined(CONFIG_IMX_HAB) || defined(CONFIG_AVB_ATX) || defined(CONFIG_IMX_TRUSTY_OS)
+#if CONFIG_IS_ENABLED(IMX_HAB) || defined(CONFIG_AVB_ATX) || defined(CONFIG_IMX_TRUSTY_OS)
 struct imx_sec_config_fuse_t const imx_sec_config_fuse = {
 	.bank = 1,
 	.word = 3,
@@ -597,7 +597,7 @@ static void imx8m_setup_csu_tzasc(void)
 	}
 }
 
-#if defined(CONFIG_IMX_HAB) && defined(CONFIG_IMX8MQ)
+#if CONFIG_IS_ENABLED(IMX_HAB) && defined(CONFIG_IMX8MQ)
 static bool is_hdmi_fused(void) {
 	struct ocotp_regs *ocotp = (struct ocotp_regs *)OCOTP_BASE_ADDR;
 	struct fuse_bank *bank = &ocotp->bank[1];
@@ -670,7 +670,7 @@ int arch_cpu_init(void)
 		if (!IS_ENABLED(CONFIG_IMX_WATCHDOG))
 			imx_set_wdog_powerdown(false);
 
-#if defined(CONFIG_IMX_HAB) && defined(CONFIG_IMX8MQ)
+#if CONFIG_IS_ENABLED(IMX_HAB) && defined(CONFIG_IMX8MQ)
 		secure_lockup();
 #endif
 		if (is_imx8md() || is_imx8mmd() || is_imx8mmdl() || is_imx8mms() ||

--- a/arch/arm/mach-imx/imx_bootaux.c
+++ b/arch/arm/mach-imx/imx_bootaux.c
@@ -133,7 +133,7 @@ int arch_auxiliary_core_up(u32 core_id, ulong addr)
 
 	/* Enable MCU */
 	if (IS_ENABLED(CONFIG_IMX8M)) {
-#if defined(CONFIG_IMX_HAB) && defined(CONFIG_ANDROID_SUPPORT)
+#if CONFIG_IS_ENABLED(IMX_HAB) && defined(CONFIG_ANDROID_SUPPORT)
 		extern int authenticate_image(
 			uint32_t ddr_start, uint32_t raw_image_size);
 		if (authenticate_image(addr, ANDROID_MCU_FIRMWARE_SIZE) != 0) {

--- a/arch/arm/mach-imx/mx6/soc.c
+++ b/arch/arm/mach-imx/mx6/soc.c
@@ -58,7 +58,7 @@ U_BOOT_DRVINFO(imx6_thermal) = {
 };
 #endif
 
-#if defined(CONFIG_IMX_HAB)
+#if CONFIG_IS_ENABLED(IMX_HAB)
 struct imx_sec_config_fuse_t const imx_sec_config_fuse = {
 	.bank = 0,
 	.word = 6,

--- a/arch/arm/mach-imx/mx7/soc.c
+++ b/arch/arm/mach-imx/mx7/soc.c
@@ -128,7 +128,7 @@ static void isolate_resource(void)
 }
 #endif
 
-#if defined(CONFIG_IMX_HAB) || defined(CONFIG_AVB_ATX)
+#if CONFIG_IS_ENABLED(IMX_HAB) || defined(CONFIG_AVB_ATX)
 struct imx_sec_config_fuse_t const imx_sec_config_fuse = {
 	.bank = 1,
 	.word = 3,

--- a/arch/arm/mach-imx/mx7ulp/soc.c
+++ b/arch/arm/mach-imx/mx7ulp/soc.c
@@ -39,7 +39,7 @@
 
 static char *get_reset_cause(char *);
 
-#if defined(CONFIG_IMX_HAB)
+#if CONFIG_IS_ENABLED(IMX_HAB)
 struct imx_sec_config_fuse_t const imx_sec_config_fuse = {
 	.bank = 29,
 	.word = 6,

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -417,7 +417,7 @@ void *spl_load_simple_fit_fix_load(const void *fit)
 	unsigned long size;
 	u8 *tmp = (u8 *)fit;
 
-	if (IS_ENABLED(CONFIG_IMX_HAB)) {
+	if (IS_ENABLED(CONFIG_SPL_IMX_HAB)) {
 		if (IS_ENABLED(CONFIG_IMX_SPL_FIT_FDT_SIGNATURE)) {
 			u32 offset = ALIGN(fdt_totalsize(fit), 0x1000);
 
@@ -533,7 +533,7 @@ int board_spl_fit_post_load(const void *fit, struct spl_image_info *spl_image)
 	int ret;
 #endif
 
-	if (CONFIG_IS_ENABLED(IMX_HAB) && !(spl_image->flags & SPL_FIT_BYPASS_POST_LOAD)) {
+	if (IS_ENABLED(CONFIG_SPL_IMX_HAB) && !(spl_image->flags & SPL_FIT_BYPASS_POST_LOAD)) {
 		u32 offset = ALIGN(fdt_totalsize(fit), 0x1000);
 
 		if (imx_hab_authenticate_image((uintptr_t)fit,


### PR DESCRIPTION
This fixes building u-boot-fio-mfgtool based on u-boot-imx 6.1.36-2.1.0.

Tested building and working on:
- imx8mm