### PR TITLE
[FIO toup] boot: image-sig: enable SHA256 algo conditionally

### DIFF
--- a/boot/image-sig.c
+++ b/boot/image-sig.c
@@ -26,6 +26,7 @@ struct checksum_algo checksum_algos[] = {
 		.calculate = hash_calculate,
 	},
 #endif
+#if CONFIG_IS_ENABLED(SHA256)
 	{
 		.name = "sha256",
 		.checksum_len = SHA256_SUM_LEN,
@@ -33,6 +34,7 @@ struct checksum_algo checksum_algos[] = {
 		.der_prefix = sha256_der_prefix,
 		.calculate = hash_calculate,
 	},
+#endif
 #if CONFIG_IS_ENABLED(SHA384)
 	{
 		.name = "sha384",


### PR DESCRIPTION
If [SPL_]SHA256 option is disabled, the hash function for sha256 is still used here, thus cannot be dropped by linker. Remove references to sha256 functions as per option.