### PR TITLE
[FIO internal] common: print errors only when BOOTFIRMWARE_INFO_STRICT

### DIFF
--- a/common/bootfirmware_info.c
+++ b/common/bootfirmware_info.c
@@ -19,8 +19,9 @@ int __weak get_boot_firmware_info(void)
 
 	node = fdt_node_offset_by_compatible(gd->fdt_blob, -1, COMPATIBLE);
 	if (node < 0) {
-		printf("Can't find node with compatible = \"" COMPATIBLE
-		       "\"\n");
+		if (CONFIG_IS_ENABLED(BOOTFIRMWARE_INFO_STRICT))
+			printf("Can't find node with compatible = \"" COMPATIBLE
+			       "\"\n");
 		ret = -FDT_ERR_NOTFOUND;
 		goto out;
 	}


### PR DESCRIPTION
Print error when a node with "lmp,bootloader" comaptible is not found only when BOOTFIRMWARE_INFO_STRICT=y.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
