### PR TITLE
[FIO internal] imx8m: use existing code for partition detection

### DIFF
--- a/arch/arm/mach-imx/imx8m/soc.c
+++ b/arch/arm/mach-imx/imx8m/soc.c
@@ -723,8 +723,7 @@ int arch_initr_trap(void)
 struct rom_api *g_rom_api = (struct rom_api *)0x980;
 #endif
 
-#if !defined(CONFIG_SECONDARY_BOOT_RUNTIME_DETECTION) && \
-    defined(CONFIG_IMX8M)
+#if defined(CONFIG_IMX8MN) || defined(CONFIG_IMX8MP)
 #include <spl.h>
 int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 {
@@ -783,6 +782,17 @@ int spl_mmc_emmc_boot_partition(struct mmc *mmc)
 	}
 
 	return part;
+}
+unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
+					   unsigned long raw_sect)
+{
+	unsigned long offset = CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR;
+#if defined(CONFIG_iMX8MN)
+	#define UBOOT_MMC2_RAW_SECTOR_OFFSET 0x40
+	if (spl_boot_device() == BOOT_DEVICE_MMC2)
+			offset -= UBOOT_MMC2_RAW_SECTOR_OFFSET;
+#endif
+	return offset;
 }
 #endif
 

--- a/arch/arm/mach-imx/spl.c
+++ b/arch/arm/mach-imx/spl.c
@@ -624,6 +624,7 @@ unsigned long spl_mmc_get_uboot_raw_sector(struct mmc *mmc,
 {
 	int boot_secondary = boot_mode_getprisec();
 	unsigned long offset = CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_SECTOR;
+
 	if (boot_secondary) {
 		offset += CONFIG_SECONDARY_BOOT_SECTOR_OFFSET;
 		printf("SPL: Booting secondary boot path: using 0x%lx offset "


### PR DESCRIPTION
Use existing implementation of spl_mmc_emmc_boot_partition() for primary/secondary boot detection for imx8mn and imx8mp.


(cherry picked from commit 6e22a1f22cbc2ccc2b238564eeded4bfcf0d2bbd)

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
